### PR TITLE
Increase GHA timeout for kogito-examples

### DIFF
--- a/.github/workflows/examples-pr.yml
+++ b/.github/workflows/examples-pr.yml
@@ -19,7 +19,7 @@ jobs:
     concurrency:
       group: examples_pr-${{ github.head_ref }}
       cancel-in-progress: true
-    timeout-minutes: 120
+    timeout-minutes: 180
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
PRs are timing out for kogito-examples because they now exceed 120 minutes.