### PR TITLE
[KOGITO-6077] fixes for kogito processes memory leak

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightWorkItemManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightWorkItemManager.java
@@ -146,6 +146,11 @@ public class LightWorkItemManager implements InternalKogitoWorkItemManager {
     }
 
     @Override
+    public void internalRemoveWorkItem(String id) {
+        workItems.remove(id);
+    }
+
+    @Override
     public void completeWorkItem(String id, Map<String, Object> results, Policy<?>... policies) {
         transitionWorkItem(id, new TransitionToComplete(results, Arrays.asList(policies)));
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
@@ -18,6 +18,7 @@ package org.jbpm.process.instance.impl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -31,8 +32,9 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
     private boolean lock = false;
 
     public void addProcessInstance(KogitoProcessInstance processInstance) {
-        String id = UUID.randomUUID().toString();
-        ((org.jbpm.process.instance.ProcessInstance) processInstance).setId(id);
+        if (Objects.isNull(processInstance.getStringId())) {
+            ((org.jbpm.process.instance.ProcessInstance) processInstance).setId(UUID.randomUUID().toString());
+        }
         internalAddProcessInstance(processInstance);
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -140,6 +140,10 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         ((InternalKogitoWorkItemManager) getProcessInstance().getKnowledgeRuntime().getWorkItemManager()).internalAddWorkItem(workItem);
     }
 
+    public void internalRemoveWorkItem() {
+        ((InternalKogitoWorkItemManager) getProcessInstance().getKnowledgeRuntime().getWorkItemManager()).internalRemoveWorkItem(workItem.getStringId());
+    }
+
     @Override
     public void internalTrigger(final KogitoNodeInstance from, String type) {
         super.internalTrigger(from, type);

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -163,6 +163,12 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
             return;
         }
 
+        for (org.kie.api.runtime.process.NodeInstance nodeInstance : processInstance.getNodeInstances()) {
+            if (nodeInstance instanceof WorkItemNodeInstance) {
+                ((WorkItemNodeInstance) nodeInstance).internalRemoveWorkItem();
+            }
+        }
+
         processInstance.disconnect();
         processInstance.setMetaData(KOGITO_PROCESS_INSTANCE, null);
     }

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceMarshaller.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceMarshaller.java
@@ -37,7 +37,6 @@ public class ProtobufProcessInstanceMarshaller implements ProcessInstanceMarshal
         RuleFlowProcessInstance pi = (RuleFlowProcessInstance) ((AbstractProcessInstance<?>) processInstance).internalGetProcessInstance();
         ProtobufProcessInstanceWriter writer = new ProtobufProcessInstanceWriter(context);
         writer.writeProcessInstance(pi, context.output());
-        pi.disconnect();
     }
 
     @Override

--- a/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/InternalKogitoWorkItemManager.java
+++ b/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/InternalKogitoWorkItemManager.java
@@ -34,6 +34,8 @@ public interface InternalKogitoWorkItemManager extends org.drools.core.process.i
 
     InternalKogitoWorkItem getWorkItem(String id);
 
+    void internalRemoveWorkItem(String id);
+
     void signalEvent(String type, Object event, String processInstanceId);
 
     void retryWorkItem(String workItemID, Map<String, Object> params);

--- a/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
+++ b/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
@@ -74,6 +74,11 @@ public class KogitoDefaultWorkItemManager implements InternalKogitoWorkItemManag
     }
 
     @Override
+    public void internalRemoveWorkItem(String id) {
+        workItems.remove(id);
+    }
+
+    @Override
     public void internalAbortWorkItem(String id) {
         KogitoWorkItemImpl workItem = (KogitoWorkItemImpl) workItems.get(id);
         // work item may have been aborted


### PR DESCRIPTION
The two main points of memory leak were:
- ProcessInstances were assigned with 2 different ids and added in the `DefaultProcessInstanceManager.addProcessInstance` that holds the process instances in a Map that were never removed
- WorkItems added and never removed in InternalKogitoWorkItemManager that holds a map with the work items, even when the process instances are disconnected

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
