### PR TITLE
Override assertj version in codestart integration-test pom

### DIFF
--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -41,6 +41,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+            <!-- Temporary override version from kogito-dependencies-bom to make sure it is api compatible with quarkus-devtools-testing -->
+            <version>3.22.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>
             <scope>test</scope>

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/filtered-resources/project.properties
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/filtered-resources/project.properties
@@ -1,3 +1,2 @@
 version=${project.version}
 artifactId=${project.artifactId}
-version.assertj=3.22.0

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java
@@ -29,21 +29,14 @@ import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Lan
 
 public class KogitoDMNCodeCodestartIT {
 
-    static final Properties properties = new Properties();
-    static {
-        try {
-            properties.load(KogitoDMNCodeCodestartIT.class.getClassLoader().getResourceAsStream("project.properties"));
-        } catch (Exception e) {
-            throw new RuntimeException("project.properties version unknown");
-        }
-    }
-
     public static String projectVersion() {
-        return properties.getProperty("version");
-    }
-
-    public static String assertjVersion() {
-        return properties.getProperty("version.assertj");
+        try {
+            final Properties properties = new Properties();
+            properties.load(KogitoDMNCodeCodestartIT.class.getClassLoader().getResourceAsStream("project.properties"));
+            return properties.getProperty("version");
+        } catch (Exception e) {
+            return "<project.properties version unknown>";
+        }
     }
 
     @RegisterExtension
@@ -51,7 +44,6 @@ public class KogitoDMNCodeCodestartIT {
             .standaloneExtensionCatalog()
             .extension(ArtifactCoords.pom("io.quarkus", "quarkus-resteasy-jackson", null)) // account for KOGITO-5817
             .extension(ArtifactCoords.fromString("org.kie.kogito:kogito-quarkus-decisions:" + projectVersion()))
-            .extension(ArtifactCoords.fromString("org.assertj:assertj-core:" + assertjVersion()))
             .putData(QuarkusDataKey.APP_CONFIG, Map.of("quarkus.http.test-port", "0"))
             .languages(JAVA)
             .build();


### PR DESCRIPTION
A cleaner fix for the issue described in https://github.com/kiegroup/kogito-runtimes/pull/2093

Temporary override version from kogito-dependencies-bom to make sure it is api compatible with quarkus-devtools-testing

This reverts commit 13155de (from https://github.com/kiegroup/kogito-runtimes/pull/2093)
