### PR TITLE
[KOGITO-8360] Support not existing nested selector on toStateData

### DIFF
--- a/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpressionHandler.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpressionHandler.java
@@ -51,7 +51,7 @@ public class JqExpressionHandler extends CachedExpressionHandler {
 
     @Override
     public Expression buildExpression(String expr) {
-        return new JqExpression(scopeSupplier, expr);
+        return new JqExpression(scopeSupplier, expr, Versions.JQ_1_6);
     }
 
     @Override

--- a/kogito-serverless-workflow/kogito-jq-expression/src/test/java/org/kie/kogito/expr/jq/JqExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/test/java/org/kie/kogito/expr/jq/JqExpressionHandlerTest.java
@@ -177,6 +177,22 @@ class JqExpressionHandlerTest {
     }
 
     @Test
+    void testAssignComplexObjectUnderGivenProperty() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".propertyObject.nestedString");
+        assertThat(parsedExpression.isValid()).isTrue();
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode toBeInserted = objectMapper.createObjectNode();
+        toBeInserted.put("bar", "value1");
+        ObjectNode targetNode = getObjectNode();
+        parsedExpression.assign(targetNode, toBeInserted, getContext());
+        assertThat(targetNode.has("bar")).as("Property 'bar' should not be in root.").isFalse();
+        assertThat(targetNode.has("propertyObject")).as("Property 'propertyObject' is missing in root.").isTrue();
+        assertThat(targetNode.get("propertyObject").has("nestedString")).as("Property 'propertyObject' should contain 'nestedString'.").isTrue();
+        assertThat(targetNode.get("propertyObject").get("nestedString").has("bar")).as("Property 'nestedString' should contain 'bar'.").isTrue();
+        assertThat(targetNode.get("propertyObject").get("nestedString").get("bar").asText()).as("Unexpected value under 'propertyObject'->'bar' property.").isEqualTo("value1");
+    }
+
+    @Test
     void testAssignArrayUnderGivenProperty() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".propertyString");
         assertThat(parsedExpression.isValid()).isTrue();

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/ExpressionHandlerUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/ExpressionHandlerUtils.java
@@ -15,12 +15,12 @@
  */
 package org.kie.kogito.serverless.workflow.utils;
 
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 import org.jbpm.ruleflow.core.Metadata;
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
-import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.jackson.utils.MergeUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -95,16 +95,47 @@ public class ExpressionHandlerUtils {
     }
 
     public static void assign(JsonNode context, JsonNode target, JsonNode value, String expr) {
+        JsonNode merged = MergeUtils.merge(value, target);
         if (context.isObject()) {
-            Optional<String> varName = fallbackVarToName(expr);
-            if (varName.isPresent()) {
-                JsonObjectUtils.addToNode(varName.get(), MergeUtils.merge(value, target), (ObjectNode) context);
+            ObjectNode root = (ObjectNode) context;
+            StringBuilder sb = new StringBuilder();
+            List<String> properties = new ArrayList<>();
+            for (int i = expr.length() - 1; i >= 0; i--) {
+                char c = expr.charAt(i);
+                if (Character.isJavaIdentifierPart(c)) {
+                    sb.insert(0, expr.charAt(i));
+                } else if (c == '.') {
+                    if (sb.length() == 0) {
+                        break;
+                    }
+                    properties.add(0, sb.toString());
+                    sb = new StringBuilder();
+                } else {
+                    if (sb.length() > 0) {
+                        properties.add(0, sb.toString());
+                    }
+                    break;
+                }
+            }
+            if (!properties.isEmpty()) {
+                int size = properties.size() - 1;
+                for (int i = 0; i < size; i++) {
+                    root = addObjectNode(root, properties.get(i));
+                }
+                root.set(properties.get(size), merged);
             }
         }
     }
 
-    public static Optional<String> fallbackVarToName(String expr) {
-        int indexOf = expr.lastIndexOf('.');
-        return indexOf < 0 ? Optional.empty() : Optional.of(expr.substring(indexOf + 1));
+    private static ObjectNode addObjectNode(ObjectNode target, String propName) {
+        if (target.has(propName)) {
+            JsonNode childNode = target.get(propName);
+            if (childNode.isObject()) {
+                return (ObjectNode) childNode;
+            }
+        }
+        ObjectNode newNode = target.objectNode();
+        target.set(propName, newNode);
+        return newNode;
     }
 }


### PR DESCRIPTION
As you see, to support the spec we need to analyze the last part of the expr (before I was just taking the last part of the expression, ignoring nested) and create the object tree accordingly. 
I do not really like this, I think toStateData should be removed and results should return the object we want to merge back to the model (and the merge rules being clearly stated) 
For example, right now, if we have a model 
`{"properties": {"tests":"pepe"}} `, action return model `{"name":"pepa"}` and toStateData is `".properties.tests"`, we need to merge an object `{"name":"pepa"}` with a string `"pepe"`, which is tricky. In this case, the result object is
`{"properties": {"tests":{"name":"pepe"}}}` so `"pepa"` is lost, which might not be the intention

An even worst case
`{"properties": {"tests":["pepe","pepa","pepi"]}`  as before, same returned json object, but toStateData is `"properties.tests.results"`, in that case the result is  `{"properties": {"tests":{"results":{"name":"pepe"}}}}`, so a whole array is gone. 

Note that these issues are not strictly related with toStateData, but if we are using results, since the user has to create the object tree to be merged into the model, he is probably more aware of the risks involved that if he just type a selector. 


