### PR TITLE
[kie-issues#511] Migrate from jboss-parent to apache parent pom.

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -144,6 +144,9 @@
     <version.versions.plugin>2.5</version.versions.plugin>
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
     <version.org.codehaus.gmavenplus.plugin>1.5</version.org.codehaus.gmavenplus.plugin>
+
+    <!-- These are added as part of the migration from JBoss to Apache parent pom.xml. They may be extracted to a KIE parent bom. -->
+    <version.maven-checkstyle>3.3.0</version.maven-checkstyle>
   </properties>
 
   <build>
@@ -181,7 +184,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>${version.checkstyle.plugin}</version>
+          <version>${version.maven-checkstyle}</version>
           <configuration>
             <checkstyleRules>
               <module name="Checker">
@@ -332,7 +335,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${version.failsafe.plugin}</version>
+          <version>${version.maven-surefire}</version>
           <executions>
             <execution>
               <id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
-    <groupId>org.jboss</groupId>
-    <artifactId>jboss-parent</artifactId>
-    <version>39</version>
-    <relativePath/>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>30</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -105,7 +105,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${version.failsafe.plugin}</version>
+          <version>${version.maven-surefire}</version>
           <configuration>
             <systemPropertyVariables>
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/springboot/integration-tests/src/it/integration-tests-springboot-processes-persistence-it/pom.xml
+++ b/springboot/integration-tests/src/it/integration-tests-springboot-processes-persistence-it/pom.xml
@@ -170,7 +170,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>@version.failsafe.plugin@</version>
+        <version>@version.maven-surefire@</version>
         <configuration>
           <classesDirectory>${project.build.outputDirectory}</classesDirectory>
           <systemPropertyVariables>


### PR DESCRIPTION
This is part of an effort from issue https://github.com/kiegroup/kie-issues/issues/511. 

- Changes root parent pom from jboss-parent to apache parent pom.xml. 
- Aligns version property names with apache parent pom. 
- Adds missing version properties. 