### PR TITLE
[KOGITO-9844] Enhace jq validation to detect invalid functions

### DIFF
--- a/kogito-serverless-workflow/kogito-jq-expression/src/test/java/org/kie/kogito/expr/jq/JqExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/test/java/org/kie/kogito/expr/jq/JqExpressionHandlerTest.java
@@ -275,6 +275,12 @@ class JqExpressionHandlerTest {
         assertThat(parsedExpression.eval(getObjectNode(), String.class, context)).isEqualTo(expectedResult);
     }
 
+    @Test
+    void testHardcodedStringIsValidOrNot() {
+        assertThat(ExpressionHandlerFactory.get("jq", "kserve_payload = to_kserve(image)").isValid()).isFalse();
+        assertThat(ExpressionHandlerFactory.get("jq", "length .variable").isValid()).isTrue();
+    }
+
     private static Stream<Arguments> provideMagicWordExpressionsToTest() {
         return Stream.of(
                 Arguments.of("$WORKFLOW.instanceId", "1111-2222-3333", getContext()),


### PR DESCRIPTION
See added test for a better understanding of the issue. Before this JIRA, isValid method was returning true for that expression, because of jq library internals. 
This PR uses reflection to try to invoke functions calls (but only function calls) as part of validation procedure. 