### PR TITLE
kie-issues#599: disable sonar in PR checks

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-kogito-runtimes'
 
-        ENABLE_SONARCLOUD = 'true'
+        ENABLE_SONARCLOUD = 'false'
         KOGITO_RUNTIMES_BUILD_MVN_OPTS = '-Dvalidate-formatting -Prun-code-coverage'
     }
     stages {


### PR DESCRIPTION
First task in regards to apache/incubator-kie-issues#599

Disabling sonar checks, as it currently breaks the build due to bug and misconfiguration.