### PR TITLE
kie-issues#622: explicitly provide startupTimeout in waitingFor call

### DIFF
--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKafkaContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKafkaContainer.java
@@ -47,7 +47,7 @@ public class KogitoKafkaContainer extends KogitoGenericContainer<KogitoKafkaCont
         withExposedPorts(KAFKA_PORT);
         withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("sh"));
         withCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
-        waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1));
+        waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1).withStartupTimeout(Constants.CONTAINER_START_TIMEOUT));
     }
 
     @Override

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKeycloakContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKeycloakContainer.java
@@ -43,7 +43,7 @@ public class KogitoKeycloakContainer extends KogitoGenericContainer<KogitoKeyclo
         withEnv("KEYCLOAK_ADMIN", USER);
         withEnv("KEYCLOAK_ADMIN_PASSWORD", PASSWORD);
         withClasspathResourceMapping("testcontainers/keycloak/kogito-realm.json", REALM_FILE, BindMode.READ_ONLY);
-        waitingFor(Wait.forLogMessage(".*Keycloak.*started.*", 1));
+        waitingFor(Wait.forLogMessage(".*Keycloak.*started.*", 1).withStartupTimeout(Constants.CONTAINER_START_TIMEOUT));
         withCommand("start-dev --import-realm");
     }
 

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoRedisSearchContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoRedisSearchContainer.java
@@ -29,7 +29,7 @@ public class KogitoRedisSearchContainer extends KogitoGenericContainer<KogitoRed
     public KogitoRedisSearchContainer() {
         super(NAME);
         addExposedPort(PORT);
-        waitingFor(Wait.forLogMessage(".*Ready to accept connections.*\\s", 1));
+        waitingFor(Wait.forLogMessage(".*Ready to accept connections.*\\s", 1).withStartupTimeout(Constants.CONTAINER_START_TIMEOUT));
     }
 
     @Override

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
@@ -18,6 +18,8 @@
  */
 package org.kie.kogito.quarkus.workflow.deployment.devservices;
 
+import java.time.Duration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -60,7 +62,7 @@ public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemo
         withEnv("KOGITO_DATA_INDEX_VERTX_GRAPHQL_UI_PATH", "/q/graphql-ui");
         withEnv("KOGITO_DATA_INDEX_QUARKUS_PROFILE", "http-events-support");
         withExposedPorts(PORT);
-        waitingFor(Wait.forHttp("/q/health/ready").forStatusCode(200));
+        waitingFor(Wait.forHttp("/q/health/ready").forStatusCode(200).withStartupTimeout(Duration.ofMinutes(5)));
     }
 
     @Override


### PR DESCRIPTION
apache/incubator-kie-issues#622

Fixing problem of overwriting default startupTimeout defined in KogitoGenericContainer class.

Providing Constants.CONTAINER_START_TIMEOUT for containers defined in kogito-test-utils module.

Another occurrence was in module kogito-quarkus-workflow-common-deployment in DataIndexInMemoryContainer class, put there 5 minutes, instead of default 60s.

