### PR TITLE
kie-issues#647: add writeJunitReport to invoker configuration

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -471,7 +471,7 @@
             <skipInvocation>${skipTests}</skipInvocation>
             <failIfNoProjects>true</failIfNoProjects>
             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-	    <writeJunitReport>true</writeJunitReport>
+            <writeJunitReport>true</writeJunitReport>
           </configuration>
         </plugin>
         <plugin>

--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -471,6 +471,7 @@
             <skipInvocation>${skipTests}</skipInvocation>
             <failIfNoProjects>true</failIfNoProjects>
             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+	    <writeJunitReport>true</writeJunitReport>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
apache/incubator-kie-issues#647

Given that CI builds set `maven.test.failure.ignore` to true, any build failure would be silently ignored, unless invoker plugin writes the build fail as a junit report with failure outcome.

This is achieved by property writeJunitReport which is false by default and needs to be overriden.

To be validated by presence of test case `maven.invoker.it.integration-tests-springboot-kafka-it.integration-tests-springboot-kafka-it` in the test results.