### PR TITLE
[KOGITO-9914] Setting LD_LIBRARY_PATH to include Jep

### DIFF
--- a/quarkus/addons/python/integration-tests/pom.xml
+++ b/quarkus/addons/python/integration-tests/pom.xml
@@ -145,6 +145,19 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+             <environmentVariables>
+               <LD_LIBRARY_PATH>${env.JAVA_HOME}/lib/server</LD_LIBRARY_PATH>
+             </environmentVariables>
+            </configuration>
+          </plugin>
+         </plugins>
+      </build>
     </profile>
   </profiles> 
 </project>


### PR DESCRIPTION
Fixing native image generation issue when using python. The Jep library was not included if LD_LIBRARY_PATH is not set. 