### PR TITLE
Try to reduce the log file size of SWF IT

### DIFF
--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtilsTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtilsTest.java
@@ -234,7 +234,6 @@ class CloudEventUtilsTest {
                         .withExtension("pepe", "pepa");
         DataEvent<JsonNode> dataEvent = DataEventFactory.from(builder.build(), ced -> objectMapper.readTree(ced.toBytes()));
         JsonNode deserialized = CloudEventUtils.fromValue(dataEvent);
-        System.out.println(deserialized);
         JsonNode data = deserialized.get("data");
         assertThat(data).isNotNull();
         assertThat(data.get("name").asText()).isEqualTo("Javierito");

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/DataEventFactoryTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/DataEventFactoryTest.java
@@ -45,7 +45,6 @@ public class DataEventFactoryTest {
                         .withExtension("pepe", "pepa");
         DataEvent<JsonNode> dataEvent = DataEventFactory.from(builder.build(), ced -> objectMapper.readTree(ced.toBytes()));
         JsonNode deserialized = objectMapper.readTree(objectMapper.writeValueAsBytes(dataEvent.asCloudEvent(JsonCloudEventData::wrap)));
-        System.out.println(deserialized);
         JsonNode data = deserialized.get("data");
 
         assertThat(data).isNotNull();

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoGenericContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoGenericContainer.java
@@ -34,7 +34,6 @@ public abstract class KogitoGenericContainer<T extends GenericContainer<T>> exte
         super(getImageName(containerName));
         withStartupTimeout(CONTAINER_START_TIMEOUT);
         withLogConsumer(new Slf4jLogConsumer(LOGGER));
-        withLogConsumer(f -> System.out.print(f.getUtf8String()));
     }
 
     public static String getImageName(String name) {

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/src/main/java/org/acme/GreetingResource.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/src/main/java/org/acme/GreetingResource.java
@@ -55,8 +55,6 @@ public class GreetingResource {
     @POST
     public DataContext hello(Map<String, Object> payload) {
         // path: /processes/scripts
-        System.out.println(payload);
-
         var id = appRoot.get(ProcessIds.class).get("scripts");
         return svc.evaluate(id, MapDataContext.from(payload));
     }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
@@ -9,7 +9,8 @@ quarkus.flyway.clean-at-start=true
 
 quarkus.http.test-port=0
 quarkus.log.level=INFO
-#quarkus.log.category."org.kie.kogito.serverless.workflow".level=DEBUG
+quarkus.log.category."org.kie.kogito.testcontainers".level=WARN
+quarkus.log.category."org.apache.kafka".level=WARN
 
 # To include the greethidden workflow
 kogito.codegen.ignoreHiddenFiles=false

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateWithTimeoutsErrorHandlerIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateWithTimeoutsErrorHandlerIT.java
@@ -67,8 +67,6 @@ class CallbackStateWithTimeoutsErrorHandlerIT extends AbstractCallbackStateIT {
     void callbackStateTimeoutsExceeded() throws Exception {
         String processInput = buildProcessInput(SUCCESSFUL_QUERY);
         String processInstanceId = newProcessInstanceAndGetId(CALLBACK_STATE_TIMEOUTS_SERVICE_URL, processInput);
-        System.out.println("processInstanceId is " + processInstanceId);
-
         assertProcessInstanceExists(CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL, processInstanceId);
 
         assertProcessInstanceHasFinished(CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL, processInstanceId, 1, 10);


### PR DESCRIPTION
This sets the level for container and kafka to warn (this generates a log of trace that does not really tell us anything unless debugging kafka or container issue, which is not the point of the test runt)

There is still an annoying system.out that is printing all kafka events, but I do not think that can be fixed in this repo