### PR TITLE
Properly trace cloud events

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
@@ -28,10 +28,7 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.kie.kogito.event.process.ProcessInstanceVariableDataEvent;
 import org.kie.kogito.test.quarkus.QuarkusTestProperty;
 import org.kie.kogito.test.quarkus.kafka.KafkaTestClient;
@@ -51,7 +48,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.waitForKogitoProcessInstanceEvent;
 
 @QuarkusIntegrationTest
-@TestMethodOrder(OrderAnnotation.class)
 class PojoServiceIT {
 
     @QuarkusTestProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
@@ -77,13 +73,11 @@ class PojoServiceIT {
     }
 
     @Test
-    @Order(1)
     void testPojo() throws Exception {
         doIt("pojoService");
     }
 
     @Test
-    @Order(2)
     void testFilterPojo() throws Exception {
         doIt("pojoServiceFilter");
     }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
@@ -150,22 +150,21 @@ class PojoServiceIT {
     }
 
     private void doIt(String flowName) throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", "javierito");
+        body.put("age", 666);
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(Collections.singletonMap("workflowdata", body))
+                .post("/" + flowName)
+                .then()
+                .statusCode(201)
+                .body("id", notNullValue())
+                .body("workflowdata.name", is("javieritoPerson"))
+                .body("workflowdata.age", nullValue());
         JsonPath processInstanceEventContent = waitForKogitoProcessInstanceEvent(kafkaClient, ProcessInstanceVariableDataEvent.class,
-                e -> flowName.equals(e.get("kogitoprocid")) && "workflowdata".equals(e.get("data.variableName")), true, () -> {
-                    Map<String, Object> body = new HashMap<>();
-                    body.put("name", "javierito");
-                    body.put("age", 666);
-                    given()
-                            .contentType(ContentType.JSON)
-                            .when()
-                            .body(Collections.singletonMap("workflowdata", body))
-                            .post("/" + flowName)
-                            .then()
-                            .statusCode(201)
-                            .body("id", notNullValue())
-                            .body("workflowdata.name", is("javieritoPerson"))
-                            .body("workflowdata.age", nullValue());
-                });
+                e -> flowName.equals(e.get("kogitoprocid")) && "workflowdata".equals(e.get("data.variableName")), true);
         Map workflowDataMap = processInstanceEventContent.getMap("data.variableValue");
         assertThat(workflowDataMap).hasSize(1);
         assertThat(workflowDataMap).containsEntry("name", "javieritoPerson");

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
@@ -28,7 +28,10 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.kie.kogito.event.process.ProcessInstanceVariableDataEvent;
 import org.kie.kogito.test.quarkus.QuarkusTestProperty;
 import org.kie.kogito.test.quarkus.kafka.KafkaTestClient;
@@ -48,6 +51,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.waitForKogitoProcessInstanceEvent;
 
 @QuarkusIntegrationTest
+@TestMethodOrder(OrderAnnotation.class)
 class PojoServiceIT {
 
     @QuarkusTestProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
@@ -73,11 +77,13 @@ class PojoServiceIT {
     }
 
     @Test
+    @Order(1)
     void testPojo() throws Exception {
         doIt("pojoService");
     }
 
     @Test
+    @Order(2)
     void testFilterPojo() throws Exception {
         doIt("pojoServiceFilter");
     }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/PojoServiceIT.java
@@ -150,21 +150,22 @@ class PojoServiceIT {
     }
 
     private void doIt(String flowName) throws Exception {
-        Map<String, Object> body = new HashMap<>();
-        body.put("name", "javierito");
-        body.put("age", 666);
-        given()
-                .contentType(ContentType.JSON)
-                .when()
-                .body(Collections.singletonMap("workflowdata", body))
-                .post("/" + flowName)
-                .then()
-                .statusCode(201)
-                .body("id", notNullValue())
-                .body("workflowdata.name", is("javieritoPerson"))
-                .body("workflowdata.age", nullValue());
         JsonPath processInstanceEventContent = waitForKogitoProcessInstanceEvent(kafkaClient, ProcessInstanceVariableDataEvent.class,
-                e -> flowName.equals(e.get("kogitoprocid")) && "workflowdata".equals(e.get("data.variableName")), true);
+                e -> flowName.equals(e.get("kogitoprocid")) && "workflowdata".equals(e.get("data.variableName")), true, () -> {
+                    Map<String, Object> body = new HashMap<>();
+                    body.put("name", "javierito");
+                    body.put("age", 666);
+                    given()
+                            .contentType(ContentType.JSON)
+                            .when()
+                            .body(Collections.singletonMap("workflowdata", body))
+                            .post("/" + flowName)
+                            .then()
+                            .statusCode(201)
+                            .body("id", notNullValue())
+                            .body("workflowdata.name", is("javieritoPerson"))
+                            .body("workflowdata.age", nullValue());
+                });
         Map workflowDataMap = processInstanceEventContent.getMap("data.variableValue");
         assertThat(workflowDataMap).hasSize(1);
         assertThat(workflowDataMap).containsEntry("name", "javieritoPerson");

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
@@ -47,6 +47,12 @@ public class WorkflowTestUtils {
 
     public static <T extends DataEvent<?>> JsonPath waitForKogitoProcessInstanceEvent(KafkaTestClient kafkaClient, Class<T> eventType, Predicate<JsonPath> predicate, boolean shutdownAfterConsume)
             throws Exception {
+        return waitForKogitoProcessInstanceEvent(kafkaClient, eventType, predicate, shutdownAfterConsume, () -> {
+        });
+    }
+
+    public static <T extends DataEvent<?>> JsonPath waitForKogitoProcessInstanceEvent(KafkaTestClient kafkaClient, Class<T> eventType, Predicate<JsonPath> predicate, boolean shutdownAfterConsume,
+            Runnable runnable) throws InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         final AtomicReference<JsonPath> cloudEvent = new AtomicReference<>();
 
@@ -61,6 +67,8 @@ public class WorkflowTestUtils {
                 countDownLatch.countDown();
             }
         });
+
+        runnable.run();
         // give some time to consume the event
         assertThat(countDownLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS)).isTrue();
         if (shutdownAfterConsume) {
@@ -68,5 +76,4 @@ public class WorkflowTestUtils {
         }
         return cloudEvent.get();
     }
-
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
@@ -47,12 +47,6 @@ public class WorkflowTestUtils {
 
     public static <T extends DataEvent<?>> JsonPath waitForKogitoProcessInstanceEvent(KafkaTestClient kafkaClient, Class<T> eventType, Predicate<JsonPath> predicate, boolean shutdownAfterConsume)
             throws Exception {
-        return waitForKogitoProcessInstanceEvent(kafkaClient, eventType, predicate, shutdownAfterConsume, () -> {
-        });
-    }
-
-    public static <T extends DataEvent<?>> JsonPath waitForKogitoProcessInstanceEvent(KafkaTestClient kafkaClient, Class<T> eventType, Predicate<JsonPath> predicate, boolean shutdownAfterConsume,
-            Runnable runnable) throws InterruptedException {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         final AtomicReference<JsonPath> cloudEvent = new AtomicReference<>();
 
@@ -67,8 +61,6 @@ public class WorkflowTestUtils {
                 countDownLatch.countDown();
             }
         });
-
-        runnable.run();
         // give some time to consume the event
         assertThat(countDownLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS)).isTrue();
         if (shutdownAfterConsume) {
@@ -76,4 +68,5 @@ public class WorkflowTestUtils {
         }
         return cloudEvent.get();
     }
+
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
@@ -52,7 +52,9 @@ public class WorkflowTestUtils {
 
         kafkaClient.consume(KOGITO_PROCESSINSTANCES_EVENTS, rawCloudEvent -> {
             JsonPath path = new JsonPath(rawCloudEvent);
-            LOGGER.debug("CLOUD EVENT:\n{}" + path.prettyPrint());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("CLOUD EVENT: {}", path.prettyPrint());
+            }
             String type = path.get("type");
             if (eventType.getSimpleName().equals(type) && predicate.test(path)) {
                 cloudEvent.set(path);


### PR DESCRIPTION
Pretty print was being called and concatenated regardless the logger is enable or not. Due to the massive amount of events that we might potentially received there, this might well explain why some test were timing out. In any case, it is a mistake that should be fixed. 

Update: 
Since the failure was still there, I tried invoking the operation after event registration, to rule out process publishing event too soon