### PR TITLE
kie-issues#667: fix cleanup and settingsXml handling

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -36,7 +36,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -95,7 +95,12 @@ pipeline {
                     maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie', getDroolsVersion())
 
                     // Need artifacts available locally
-                    getMavenCommand().withProperty('quickly').run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand()
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                     maven.mvnSetVersionProperty(getMavenCommand(getWorkflowCommonDeploymentPath()), 'data-index-ephemeral.image', getDataIndexEphemeralReleaseImage())
                 }
             }
@@ -112,7 +117,11 @@ pipeline {
                         if (params.SKIP_TESTS) {
                             mvnCmd.skipTests() // Conflict somehow with Python testing. If `skipTests={anyvalue}` is set, then exec plugin is not executed ...
                         }
-                        mvnCmd.run('clean install')
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            mvnCmd
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                        }
                     }
                 }
             }
@@ -196,7 +205,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -286,7 +295,6 @@ void setDeployPropertyIfNeeded(String key, def value) {
 MavenCommand getMavenCommand(String directory = '') {
     directory = directory ?: getRepoName()
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .inDirectory(directory)
                 .withProperty('full')
@@ -303,7 +311,12 @@ void runMavenDeploy(boolean localDeployment = false) {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
-    mvnCmd.skipTests(true).run('clean deploy')
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        mvnCmd
+            .skipTests(true)
+            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+            .run('clean deploy')
+    }
 }
 
 String getMavenRepoZipUrl() {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -91,17 +91,28 @@ pipeline {
             }
             steps {
                 script {
-                    maven.mvnVersionsSet(getMavenCommand(), getProjectVersion(), !isRelease())
-                    maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie', getDroolsVersion())
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        maven.mvnVersionsSet(
+                            getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            getProjectVersion(),
+                            !isRelease()
+                        )
+                        maven.mvnSetVersionProperty(
+                            getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            'version.org.kie', getDroolsVersion()
+                        )
 
                     // Need artifacts available locally
-                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
                         getMavenCommand()
                             .withProperty('quickly')
                             .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                             .run('clean install')
+                        maven.mvnSetVersionProperty(
+                            getMavenCommand(getWorkflowCommonDeploymentPath()).withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            'data-index-ephemeral.image',
+                            getDataIndexEphemeralReleaseImage()
+                        )
                     }
-                    maven.mvnSetVersionProperty(getMavenCommand(getWorkflowCommonDeploymentPath()), 'data-index-ephemeral.image', getDataIndexEphemeralReleaseImage())
                 }
             }
         }
@@ -324,13 +335,15 @@ String getMavenRepoZipUrl() {
 }
 
 void runMavenStage() {
-    MavenStagingHelper stagingHelper = getStagingHelper()
-    deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
-    stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        MavenStagingHelper stagingHelper = getStagingHelper(getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE))
+        deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
+        stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    }
 }
 
-MavenStagingHelper getStagingHelper() {
-    return new MavenStagingHelper(this, getMavenCommand())
+MavenStagingHelper getStagingHelper(MavenCommand mavenCommand) {
+    return new MavenStagingHelper(this, mavenCommand)
         .withNexusReleaseUrl(env.NEXUS_RELEASE_URL)
         .withNexusReleaseRepositoryId(env.NEXUS_RELEASE_REPOSITORY_ID)
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -25,7 +25,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME != '') {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -73,7 +73,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
@@ -21,7 +21,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     sh 'printenv > env_props'
                     archiveArtifacts artifacts: 'env_props'
@@ -40,7 +40,12 @@ pipeline {
                     dir('drools') {
                         githubscm.checkoutIfExists('incubator-kie-drools', changeAuthor, changeBranch, 'apache', changeTarget, true)
                         sh '.ci/environments/update.sh quarkus-3'
-                        getMavenCommand().withProperty('quickly').run('clean install')
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            getMavenCommand()
+                                .withProperty('quickly')
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                        }
                     }
                 }
             }
@@ -70,10 +75,8 @@ pipeline {
         }
     }
     post {
-        always {
-            script {
-                cleanWs()
-            }
+        cleanup {
+            cleanWs()
         }
         unsuccessful {
             script {
@@ -93,6 +96,5 @@ String getGitAuthorCredsId() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
 }

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
@@ -58,7 +58,12 @@ pipeline {
                     dir('drools') {
                         githubscm.checkoutIfExists('incubator-kie-drools', getGitAuthor(), getBuildBranch(), getBaseAuthor(), getBaseBranch(), true)
                         sh '.ci/environments/update.sh quarkus-3'
-                        getMavenCommand().withProperty('quickly').run('clean install')
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            getMavenCommand()
+                                .withProperty('quickly')
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                .run('clean install')
+                        }
                     }
                 }
             }
@@ -117,7 +122,7 @@ pipeline {
 
 void clean() {
     sh 'rm -rf ~/.rewrite-cache/'
-    util.cleanNode('docker')
+    util.cleanNode()
 }
 
 void sendErrorNotification() {
@@ -171,6 +176,5 @@ String getPRBranch() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -27,7 +27,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -41,11 +41,14 @@ pipeline {
         stage('Build Drools') {
             steps {
                 script {
-                    getMavenCommand(droolsRepo)
-                        .withProperty('quickly')
-                        .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withOptions(env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ? [ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(droolsRepo)
+                            .withProperty('quickly')
+                            .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withOptions(env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ? [ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
@@ -56,7 +59,12 @@ pipeline {
                     maven.mvnSetVersionProperty(getMavenCommand(getRepoName()), 'version.org.kie', getDroolsVersion())
 
                     // Need artifacts available locally
-                    getMavenCommand(getRepoName()).withProperty('quickly').run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(getRepoName())
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                     maven.mvnSetVersionProperty(getMavenCommand(getRepoName()).withOptions(['-pl :kogito-quarkus-workflow-common-deployment']), 'data-index-ephemeral.image', getDataIndexEphemeralImage())
                 }
             }
@@ -84,7 +92,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -146,7 +154,6 @@ String getGitAuthorCredsID() {
 
 MavenCommand getMavenCommand(String directory) {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .inDirectory(directory)
 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -55,17 +55,33 @@ pipeline {
         stage('Update project version') {
             steps {
                 script {
-                    maven.mvnVersionsSet(getMavenCommand(getRepoName()).withProperty('full'), getKogitoVersion(), true)
-                    maven.mvnSetVersionProperty(getMavenCommand(getRepoName()), 'version.org.kie', getDroolsVersion())
-
-                    // Need artifacts available locally
                     configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        maven.mvnVersionsSet(
+                            getMavenCommand(getRepoName())
+                                .withProperty('full')
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            getKogitoVersion(),
+                            true
+                        )
+                        maven.mvnSetVersionProperty(
+                            getMavenCommand(getRepoName()).withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            'version.org.kie',
+                            getDroolsVersion()
+                        )
+
+                        // Need artifacts available locally
                         getMavenCommand(getRepoName())
                             .withProperty('quickly')
                             .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                             .run('clean install')
+                        maven.mvnSetVersionProperty(
+                            getMavenCommand(getRepoName())
+                                .withOptions(['-pl :kogito-quarkus-workflow-common-deployment'])
+                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            'data-index-ephemeral.image',
+                            getDataIndexEphemeralImage()
+                        )
                     }
-                    maven.mvnSetVersionProperty(getMavenCommand(getRepoName()).withOptions(['-pl :kogito-quarkus-workflow-common-deployment']), 'data-index-ephemeral.image', getDataIndexEphemeralImage())
                 }
             }
         }


### PR DESCRIPTION
apache/incubator-kie-issues#667

Fixing cleanup and settings.xml pipeline configuration to work correctly in ASF Jenkins.

* Deferred wipeout was causing issues when invoked in early stages
* Docker cleanup can't be done since the overall build is in docker container that uses the docker.sock from the host - it would attempt to erase itself.
* withSettingsXmlId shared library method does imply usage of a prohibited groovy method, thus replacing with explicit configFileProvider and passing as withSettingsXmlFile goes around that part of code. 

Complete list:
apache/incubator-kie-kogito-pipelines#1113
apache/incubator-kie-kogito-runtimes#3272
apache/incubator-kie-kogito-apps#1909
apache/incubator-kie-kogito-examples#1820
apache/incubator-kie-drools#5572
apache/incubator-kie-optaplanner#3010
apache/incubator-kie-optaplanner-quickstarts#613
apache/incubator-kie-kogito-docs#514
apache/incubator-kie-docs#4531
apache/incubator-kie-benchmarks#273