### PR TITLE
kie-issues#599: set projectKey for sonarcloud

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-kogito-runtimes'
 
         ENABLE_SONARCLOUD = 'false'
+        SONAR_PROJECT_KEY = 'apache_incubator-kie-kogito-runtimes'
         KOGITO_RUNTIMES_BUILD_MVN_OPTS = '-Dvalidate-formatting -Prun-code-coverage'
     }
     stages {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -99,9 +99,17 @@ Utils.isMainBranch(this) && KogitoJobTemplate.createPullRequestMultibranchPipeli
 createSetupBranchJob()
 
 // Nightly jobs
+Closure setupSonarProjectKeyEnv = { Closure paramsGetter ->
+    return { script ->
+        def jobParams = paramsGetter(script)
+        jobParams.env.put('SONAR_PROJECT_KEY', 'apache_incubator-kie-kogito-runtimes')
+        return jobParams
+    }
+}
+
 Closure nightlyJobParamsGetter = isMainStream() ? JobParamsUtils.DEFAULT_PARAMS_GETTER : setup4AMCronTriggerJobParamsGetter
 KogitoJobUtils.createNightlyBuildChainBuildAndDeployJobForCurrentRepo(this, '', true)
-setupSpecificBuildChainNightlyJob('sonarcloud', nightlyJobParamsGetter)
+setupSpecificBuildChainNightlyJob('sonarcloud', setupSonarProjectKeyEnv(nightlyJobParamsGetter))
 setupSpecificBuildChainNightlyJob('native', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-main', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-branch', nightlyJobParamsGetter)


### PR DESCRIPTION
apache/incubator-kie-issues#599

Explicitly setting sonar.projectKey in PR checks and buildchain nightly.

apache/incubator-kie-drools#5573
apache/incubator-kie-kogito-apps#1910
apache/incubator-kie-kogito-pipelines#1116
apache/incubator-kie-kogito-runtimes#3274
apache/incubator-kie-optaplanner#3011