### PR TITLE
Remove python from default profile

### DIFF
--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -47,7 +47,6 @@
         <module>tracing-decision</module>
         <module>task-management</module>
         <module>marshallers</module>
-        <module>python</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
This carry backward change from main to 1.40.x
