### PR TITLE
NO_ISSUE: Fix testEscalationBoundaryEventInterruptsTask

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java
@@ -114,8 +114,6 @@ public class EscalationEventTest extends JbpmBpmn2TestCase {
     }
 
     @Test
-    @Disabled("Escalation does not cancel work items yet.")
-    // TODO: make escalation interrupt tasks -- or look more closely at the spec to make sure that's the case? 
     public void testEscalationBoundaryEventInterruptsTask() throws Exception {
         kruntime = createKogitoProcessRuntime("escalation/BPMN2-EscalationBoundaryEventInterrupting.bpmn2");
         TestWorkItemHandler handler = new TestWorkItemHandler();

--- a/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
+++ b/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
@@ -86,7 +86,9 @@ public class KogitoDefaultWorkItemManager implements InternalKogitoWorkItemManag
             KogitoWorkItemHandler handler = this.workItemHandlers.get(workItem.getName());
             if (handler != null) {
                 handler.abortWorkItem(workItem, this);
+                workItem.setState(ABORTED);
             } else {
+                workItem.setState(ABORTED);
                 workItems.remove(workItem.getStringId());
                 throw new KogitoWorkItemHandlerNotFoundException(workItem.getName());
             }


### PR DESCRIPTION
This pull request fixes `testEscalationBoundaryEventInterruptsTask()` that can be enabled again.