### PR TITLE
kie-issues#742: upgrade jacoco maven plugin to 0.8.11

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -116,7 +116,7 @@
     <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
     <version.install.plugin>2.5.2</version.install.plugin>
     <version.invoker.plugin>3.2.2</version.invoker.plugin>
-    <version.jacoco.plugin>0.8.5</version.jacoco.plugin>
+    <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <jandex-maven-plugin.group-id>io.smallrye</jandex-maven-plugin.group-id>
     <version.jandex.plugin>3.0.5</version.jandex.plugin>
     <version.jar.plugin>3.1.0</version.jar.plugin>


### PR DESCRIPTION
Fixes:
* apache/incubator-kie-issues#742

Upgrading jacoco maven plugin version due to JDK 17 issues we've seen in CI after JDK upgrade.