### PR TITLE
Using different topics

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/callback-state-with-timeouts-error-handler.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/callback-state-with-timeouts-error-handler.sw.json
@@ -37,7 +37,7 @@
     {
       "name": "publishTimeoutExpired",
       "type": "asyncapi",
-      "operation": "specs/callbackResults.yaml#sendTimeoutExpired"
+      "operation": "specs/callbackResults.yaml#sendTimeoutExpiredForCallbackError"
     },
     {
       "name": "publishFailure",

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventWithError.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventWithError.sw.json
@@ -27,7 +27,7 @@
     {
       "name": "publishTimeoutExpired",
       "type": "asyncapi",
-      "operation": "specs/callbackResults.yaml#sendTimeoutExpired"
+      "operation": "specs/callbackResults.yaml#sendTimeoutExpiredError"
     }
   ]
   ,

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/callbackResults.yaml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/callbackResults.yaml
@@ -21,10 +21,17 @@ channels:
       summary: Success
       message:
         $ref: '#/components/messages/message'
-  timeout:
-    description: A message channel for expired timeouts
+  timeoutCallbackError:
+    description: A message channel for callback timeout error
     publish:
-      operationId: sendTimeoutExpired
+      operationId: sendTimeoutExpiredForCallbackError
+      summary: Timeout Expired
+      message:
+        $ref: '#/components/messages/message'
+  timeoutError:
+    description: A message channel for timeout error
+    publish:
+      operationId: sendTimeoutExpiredError
       summary: Timeout Expired
       message:
         $ref: '#/components/messages/message'

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateTimeoutsIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateTimeoutsIT.java
@@ -18,7 +18,6 @@
  */
 package org.kie.kogito.quarkus.workflows;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
 
@@ -50,7 +49,6 @@ class CallbackStateTimeoutsIT extends AbstractCallbackStateIT {
                 CALLBACK_STATE_TIMEOUTS_TOPIC);
     }
 
-    @Disabled("https://github.com/apache/incubator-kie-kogito-runtimes/issues/3320")
     @Test
     void callbackStateTimeoutsExceeded() {
         // start a new process instance by sending a query and collect the process instance id.

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateWithTimeoutsErrorHandlerIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateWithTimeoutsErrorHandlerIT.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.event.Converter;
 import org.kie.kogito.event.cloudevents.CloudEventExtensionConstants;
@@ -64,7 +63,6 @@ class CallbackStateWithTimeoutsErrorHandlerIT extends AbstractCallbackStateIT {
         waitForFinalizedEvent(processInstanceId, "success");
     }
 
-    @Disabled("https://github.com/apache/incubator-kie-kogito-runtimes/issues/3320")
     @Test
     void callbackStateTimeoutsExceeded() throws Exception {
         String processInput = buildProcessInput(SUCCESSFUL_QUERY);
@@ -72,7 +70,7 @@ class CallbackStateWithTimeoutsErrorHandlerIT extends AbstractCallbackStateIT {
         assertProcessInstanceExists(CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL, processInstanceId);
 
         assertProcessInstanceHasFinished(CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL, processInstanceId, 1, 10);
-        waitForFinalizedEvent(processInstanceId, "timeout");
+        waitForFinalizedEvent(processInstanceId, "timeoutCallbackError");
     }
 
     @Test

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EventTimedoutIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EventTimedoutIT.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.event.Converter;
 import org.kie.kogito.event.cloudevents.CloudEventExtensionConstants;
@@ -76,13 +75,12 @@ public class EventTimedoutIT {
         }
     }
 
-    @Disabled("https://github.com/apache/incubator-kie-kogito-runtimes/issues/3320")
     @Test
     void testTimedout() throws InterruptedException {
         String id = startProcess("eventTimedout");
         Converter<byte[], CloudEvent> converter = new ByteArrayCloudEventUnmarshallerFactory(objectMapper).unmarshaller(Map.class).cloudEvent();
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        kafkaClient.consume("timeout", v -> {
+        kafkaClient.consume("timeoutError", v -> {
             try {
                 CloudEvent event = converter.convert(v);
                 if (id.equals(event.getExtension(CloudEventExtensionConstants.PROCESS_INSTANCE_ID))) {


### PR DESCRIPTION
Seems that either the test are executed on parallel or the same container is being reused for the same test. In both cases, the tests might fail randomly because they share the same topic. Therefore, the best approach is to  use different ones so they are fully independent. 