### PR TITLE
[kie-issues#754] Use UTF-8 on important places during Quarkus build

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/io/CollectedResourceProducer.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/io/CollectedResourceProducer.java
@@ -104,7 +104,7 @@ public class CollectedResourceProducer {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
-                InternalResource resource = new ByteArrayResource(readBytesFromInputStream(zipFile.getInputStream(entry)));
+                InternalResource resource = new ByteArrayResource(readBytesFromInputStream(zipFile.getInputStream(entry)), StandardCharsets.UTF_8.name());
                 resource.setSourcePath(entry.getName());
                 resources.add(toCollectedResource(jarPath, entry.getName(), resource));
             }

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/io/CollectedResourceProducer.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/io/CollectedResourceProducer.java
@@ -21,6 +21,7 @@ package org.kie.kogito.codegen.core.io;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -171,7 +172,7 @@ public class CollectedResourceProducer {
     }
 
     private static CollectedResource toCollectedResource(Path basePath, File file) {
-        Resource resource = new FileSystemResource(file);
+        Resource resource = new FileSystemResource(file, StandardCharsets.UTF_8.name());
         return toCollectedResource(basePath, file.getName(), resource);
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/754

[Dependant Drools PR](https://github.com/apache/incubator-kie-drools/pull/5620)

Uses UTF-8 on important places during the Quarkus build. I suggest we should do a broader encoding review during next year. There are more places, like e.g. calling String.getBytes() without encoding and similar on many places. Unfortunately this is very hard to test, as the behaviour I was fixing only happens on an environment that doesn't use UTF-8, so there are no new test cases added. If you know about some option how to add such tests, please let me know and I will add them. 