### PR TITLE
[Fix_@818] Fixing native python test on Java 17

### DIFF
--- a/quarkus/addons/python/integration-tests/pom.xml
+++ b/quarkus/addons/python/integration-tests/pom.xml
@@ -152,7 +152,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
              <environmentVariables>
-               <LD_LIBRARY_PATH>${env.JAVA_HOME}/lib/server</LD_LIBRARY_PATH>
+               <LD_LIBRARY_PATH>${env.JAVA_HOME}/lib/server;${env.GRAALVM_HOME}/lib/server</LD_LIBRARY_PATH>
              </environmentVariables>
             </configuration>
           </plugin>

--- a/quarkus/addons/python/integration-tests/src/test/java/org/kie/kogito/quarkus/workflows/PythonFlowIT.java
+++ b/quarkus/addons/python/integration-tests/src/test/java/org/kie/kogito/quarkus/workflows/PythonFlowIT.java
@@ -20,7 +20,6 @@ package org.kie.kogito.quarkus.workflows;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.DisabledOnIntegrationTest;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 
@@ -28,9 +27,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusIntegrationTest
-@DisabledOnIntegrationTest(
-        value = "Temporarily disabling test since python cannot be properly initialized inside the native image",
-        forArtifactTypes = DisabledOnIntegrationTest.ArtifactType.NATIVE_BINARY)
 class PythonFlowIT {
 
     @Test

--- a/quarkus/addons/python/runtime/src/main/resources/META-INF/native-image/jni-config.json
+++ b/quarkus/addons/python/runtime/src/main/resources/META-INF/native-image/jni-config.json
@@ -29,6 +29,7 @@
   {
     "name": "java.util.Map$Entry[]"
   },
+  {"name":"java.lang.reflect.AnnotatedElement", "allPublicMethods": true},
   {"name":"java.lang.IllegalStateException","allPublicMethods":true},
   {"name":"java.lang.NoSuchMethodError","allPublicMethods":true,"allPublicConstructors":true, "allPublicClasses": true},
   {"name":"java.lang.IllegalStateException[]","allPublicMethods":true},
@@ -238,6 +239,10 @@
     "name": "jep.MainInterpreter"
   },
   {
+  	"name": "jep.PyMethod",
+  	"allPublicMethods": true
+  },
+  {
     "name": "jep.NDArray",
     "allPublicMethods": true,
     "allPublicConstructors": true
@@ -245,5 +250,9 @@
   {
     "name": "jep.ClassList",
     "allPublicMethods": true
+  },
+  {
+  	"name": "java.lang.reflect.Executable",
+  	"allPublicMethods": true
   }
 ]


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/818
LD_LIBRARY_PATH should point either to graalvm_home|java_home/server/lib and some extra classes (mainly jdk ones) are needed in the jni set. 