### PR TITLE
Upgrade maven version to 3.9.5 version on gitlab actions ci

### DIFF
--- a/.github/workflows/pr-kogito-runtimes.yml
+++ b/.github/workflows/pr-kogito-runtimes.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [17]
-        maven-version: ['3.9.3']
+        maven-version: ['3.9.5']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }}


### PR DESCRIPTION
This pull request is aiming to upgrade the maven version to the latest version on Github Actions ci for `Kogito Runtimes `  building workflow 

