### PR TITLE
[Fix_#3366] Configuring exception propagation for event publishing

### DIFF
--- a/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/config/EventsRuntimeConfig.java
+++ b/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/config/EventsRuntimeConfig.java
@@ -46,7 +46,7 @@ public class EventsRuntimeConfig {
     /**
      * Propagate errors for process definition emitter
      */
-    @ConfigItem(name = "processdefinition.errors.propagate", defaultValue = "false")
+    @ConfigItem(name = "processdefinitions.errors.propagate", defaultValue = "false")
     boolean processDefinitionPropagate;
 
     /**

--- a/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/config/EventsRuntimeConfig.java
+++ b/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/config/EventsRuntimeConfig.java
@@ -32,16 +32,34 @@ public class EventsRuntimeConfig {
     boolean processInstancesEventsEnabled;
 
     /**
+     * Propagate errors for process instance emitter
+     */
+    @ConfigItem(name = "processinstances.errors.propagate", defaultValue = "false")
+    boolean processInstancesPropagate;
+
+    /**
      * Enable publishing processes definition events
      */
     @ConfigItem(name = "processdefinitions.enabled", defaultValue = "true")
     boolean processDefinitionEventsEnabled;
 
     /**
+     * Propagate errors for process definition emitter
+     */
+    @ConfigItem(name = "processdefinition.errors.propagate", defaultValue = "false")
+    boolean processDefinitionPropagate;
+
+    /**
      * Enable publishing user task instances events
      */
     @ConfigItem(name = "usertasks.enabled", defaultValue = "true")
     boolean userTasksEventsEnabled;
+
+    /**
+     * Propagate errors for user task emitter
+     */
+    @ConfigItem(name = "usertasks.errors.propagate", defaultValue = "false")
+    boolean userTasksPropagate;
 
     public boolean isProcessInstancesEventsEnabled() {
         return processInstancesEventsEnabled;
@@ -53,6 +71,18 @@ public class EventsRuntimeConfig {
 
     public boolean isUserTasksEventsEnabled() {
         return userTasksEventsEnabled;
+    }
+
+    public boolean isProcessInstancesPropagateError() {
+        return processInstancesPropagate;
+    }
+
+    public boolean isProcessDefinitionPropagateError() {
+        return processDefinitionPropagate;
+    }
+
+    public boolean isUserTasksPropagateError() {
+        return userTasksPropagate;
     }
 
 }

--- a/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/process/ReactiveMessagingEventPublisher.java
+++ b/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/process/ReactiveMessagingEventPublisher.java
@@ -137,7 +137,7 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
     }
 
     protected CompletionStage<Void> onAck(Message<String> message) {
-        logger.debug("Successfully published message {}", message);
+        logger.debug("Successfully published message {}", message.getPayload());
         return CompletableFuture.completedFuture(null);
     }
 
@@ -154,6 +154,7 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
         @Override
         public void accept(MutinyEmitter<String> emitter, Message<String> message) {
             emitter.sendMessageAndAwait(message);
+            logger.debug("Successfully published message {}", message.getPayload());
         }
     }
 

--- a/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/process/ReactiveMessagingEventPublisher.java
+++ b/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/process/ReactiveMessagingEventPublisher.java
@@ -21,6 +21,7 @@ package org.kie.kogito.events.process;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -52,14 +53,17 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
     @Inject
     @Channel(PROCESS_INSTANCES_TOPIC_NAME)
     MutinyEmitter<String> processInstancesEventsEmitter;
+    private BiConsumer<MutinyEmitter<String>, Message<String>> processInstanceConsumer;
 
     @Inject
     @Channel(PROCESS_DEFINITIONS_TOPIC_NAME)
     MutinyEmitter<String> processDefinitionEventsEmitter;
+    private BiConsumer<MutinyEmitter<String>, Message<String>> processDefinitionConsumer;
 
     @Inject
     @Channel(USER_TASK_INSTANCES_TOPIC_NAME)
     MutinyEmitter<String> userTasksEventsEmitter;
+    private BiConsumer<MutinyEmitter<String>, Message<String>> userTaskConsumer;
     @Inject
     EventsRuntimeConfig eventsRuntimeConfig;
 
@@ -71,6 +75,9 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
     @PostConstruct
     public void init() {
         decoratorProvider = decoratorProviderInstance.isResolvable() ? decoratorProviderInstance.get() : null;
+        processInstanceConsumer = eventsRuntimeConfig.isProcessInstancesPropagateError() ? new BlockingMessageEmitter() : new ReactiveMessageEmitter();
+        processDefinitionConsumer = eventsRuntimeConfig.isProcessDefinitionPropagateError() ? new BlockingMessageEmitter() : new ReactiveMessageEmitter();
+        userTaskConsumer = eventsRuntimeConfig.isUserTasksPropagateError() ? new BlockingMessageEmitter() : new ReactiveMessageEmitter();
     }
 
     @Override
@@ -79,7 +86,7 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
         switch (event.getType()) {
             case "ProcessDefinitionEvent":
                 if (eventsRuntimeConfig.isProcessDefinitionEventsEnabled()) {
-                    publishToTopic(event, processDefinitionEventsEmitter, PROCESS_DEFINITIONS_TOPIC_NAME);
+                    publishToTopic(processDefinitionConsumer, event, processDefinitionEventsEmitter, PROCESS_DEFINITIONS_TOPIC_NAME);
                 }
                 break;
             case "ProcessInstanceErrorDataEvent":
@@ -88,7 +95,7 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
             case "ProcessInstanceStateDataEvent":
             case "ProcessInstanceVariableDataEvent":
                 if (eventsRuntimeConfig.isProcessInstancesEventsEnabled()) {
-                    publishToTopic(event, processInstancesEventsEmitter, PROCESS_INSTANCES_TOPIC_NAME);
+                    publishToTopic(processInstanceConsumer, event, processInstancesEventsEmitter, PROCESS_INSTANCES_TOPIC_NAME);
                 }
                 break;
 
@@ -99,7 +106,7 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
             case "UserTaskInstanceStateDataEvent":
             case "UserTaskInstanceVariableDataEvent":
                 if (eventsRuntimeConfig.isUserTasksEventsEnabled()) {
-                    publishToTopic(event, userTasksEventsEmitter, USER_TASK_INSTANCES_TOPIC_NAME);
+                    publishToTopic(userTaskConsumer, event, userTasksEventsEmitter, USER_TASK_INSTANCES_TOPIC_NAME);
                 }
                 break;
             default:
@@ -114,31 +121,48 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
         }
     }
 
-    protected void publishToTopic(DataEvent<?> event, MutinyEmitter<String> emitter, String topic) {
+    protected void publishToTopic(BiConsumer<MutinyEmitter<String>, Message<String>> consumer, DataEvent<?> event, MutinyEmitter<String> emitter, String topic) {
         logger.debug("About to publish event {} to topic {}", event, topic);
+        Message<String> message = null;
         try {
             String eventString = json.writeValueAsString(event);
-            Message<String> message = decorateMessage(ContextAwareMessage.of(eventString));
-
             logger.debug("Event payload '{}'", eventString);
-            emitter.sendMessageAndAwait(message);
-
+            message = decorateMessage(ContextAwareMessage.of(eventString));
         } catch (Exception e) {
-            logger.error("Error while creating event to topic {} for event {}", topic, event, e);
+            logger.error("Error while creating event to topic {} for event {}", topic, event);
+        }
+        if (message != null) {
+            consumer.accept(emitter, message);
         }
     }
 
-    protected CompletionStage<Void> onAck(DataEvent<?> event, String topic) {
-        logger.debug("Successfully published event {} to topic {}", event, topic);
+    protected CompletionStage<Void> onAck(Message<String> message) {
+        logger.debug("Successfully published message {}", message);
         return CompletableFuture.completedFuture(null);
     }
 
-    protected CompletionStage<Void> onNack(Throwable reason, DataEvent<?> event, String topic) {
-        logger.error("Error while publishing event to topic {} for event {}", topic, event, reason);
+    protected CompletionStage<Void> onNack(Throwable reason, Message<String> message) {
+        logger.error("Error while publishing message {}", message, reason);
         return CompletableFuture.completedFuture(null);
     }
 
     protected Message<String> decorateMessage(Message<String> message) {
         return decoratorProvider != null ? decoratorProvider.decorate(message) : message;
+    }
+
+    private class BlockingMessageEmitter implements BiConsumer<MutinyEmitter<String>, Message<String>> {
+        @Override
+        public void accept(MutinyEmitter<String> emitter, Message<String> message) {
+            emitter.sendMessageAndAwait(message);
+        }
+    }
+
+    private class ReactiveMessageEmitter implements BiConsumer<MutinyEmitter<String>, Message<String>> {
+        @Override
+        public void accept(MutinyEmitter<String> emitter, Message<String> message) {
+            emitter.sendMessageAndForget(message
+                    .withAck(() -> onAck(message))
+                    .withNack(reason -> onNack(reason, message)));
+        }
     }
 }


### PR DESCRIPTION
The new configurable properties are 
```
kogito.events.processinstances.errors.propagate
kogito.events.processdefinitions.errors.propagate
kogito.events.usertasks.errors.propagate
```
Default value is false, so exception wont be propaged unless explicitly indicated

I manually tested that when 
`kogito.events.processdefinitions.errors.propagate=true`
and 
`mp.messaging.outgoing.kogito-processdefinitions-events.connector=quarkus-http`
if there is not data-index, quarkus wont start. 

```
2024-01-30 19:11:39,813 ERROR [io.qua.run.Application] (Quarkus Main Thread) Failed to start application (with profile [dev]): java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.runner.bootstrap.StartupActionImpl$1.run(StartupActionImpl.java:104)
	at java.base/java.lang.Thread.run(Thread.java:840)

```