### PR TITLE
[Fix_3383] Adding binary cloud event support for outgoing messages

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/GlobalObjectMapperQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/GlobalObjectMapperQuarkusTemplate.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 
 import jakarta.inject.Inject;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -44,5 +45,6 @@ public class GlobalObjectMapper implements ObjectMapperCustomizer {
         }
         mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
         mapper.registerModule(new JavaTimeModule()).registerModule(JsonFormat.getCloudEventJacksonModule());
+        mapper.setSerializationInclusion(Include.NON_NULL);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/GlobalObjectMapperQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/GlobalObjectMapperQuarkusTemplate.java
@@ -24,7 +24,6 @@ import java.util.TimeZone;
 
 import jakarta.inject.Inject;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -45,6 +44,5 @@ public class GlobalObjectMapper implements ObjectMapperCustomizer {
         }
         mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
         mapper.registerModule(new JavaTimeModule()).registerModule(JsonFormat.getCloudEventJacksonModule());
-        mapper.setSerializationInclusion(Include.NON_NULL);
     }
 }

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventEmitter.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventEmitter.java
@@ -20,10 +20,12 @@ package org.kie.kogito.addon.quarkus.messaging.common;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
 import org.kie.kogito.addon.quarkus.common.reactive.messaging.MessageDecoratorProvider;
 import org.kie.kogito.event.CloudEventMarshaller;
 import org.kie.kogito.event.DataEvent;
@@ -31,6 +33,9 @@ import org.kie.kogito.event.EventEmitter;
 import org.kie.kogito.event.EventMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadataBuilder;
 
 import jakarta.inject.Inject;
 
@@ -49,11 +54,11 @@ public abstract class AbstractQuarkusCloudEventEmitter<M> implements EventEmitte
     public CompletionStage<Void> emit(DataEvent<?> dataEvent) {
         logger.debug("publishing event {}", dataEvent);
         try {
-            Message<M> message = messageDecorator.decorate(Message.of(getPayload(dataEvent))
+            Message<M> message = messageDecorator.decorate(getMessage(dataEvent))
                     .withNack(e -> {
                         logger.error("Error publishing event {}", dataEvent, e);
                         return CompletableFuture.completedFuture(null);
-                    }));
+                    });
             emit(message);
             return message.getAck().get();
         } catch (IOException e) {
@@ -69,11 +74,26 @@ public abstract class AbstractQuarkusCloudEventEmitter<M> implements EventEmitte
         this.cloudEventMarshaller = marshaller;
     }
 
-    private <T> M getPayload(DataEvent<T> event) throws IOException {
+    private <T> Optional<OutgoingCloudEventMetadata<?>> getMetadata(DataEvent<T> event) {
+        if (event.getId() == null || event.getType() == null || event.getSource() == null || event.getSpecVersion() == null) {
+            return Optional.empty();
+        }
+        OutgoingCloudEventMetadataBuilder<Object> builder = OutgoingCloudEventMetadata.builder().withId(event.getId()).withSource(event.getSource()).withType(event.getType())
+                .withSubject(event.getSubject())
+                .withDataContentType(event.getDataContentType()).withDataSchema(event.getDataSchema()).withSpecVersion(event.getSpecVersion().name()).withTimestamp(event.getTime().toZonedDateTime());
+        for (String extName : event.getExtensionNames()) {
+            builder.withExtension(extName, event.getExtension(extName));
+        }
+        return Optional.of(builder.build());
+    }
+
+    private <T> Message<M> getMessage(DataEvent<T> event) throws IOException {
         if (cloudEventMarshaller != null) {
-            return cloudEventMarshaller.marshall(event.asCloudEvent(cloudEventMarshaller.cloudEventDataFactory()));
+            return Message.of(cloudEventMarshaller.marshall(event.asCloudEvent(cloudEventMarshaller.cloudEventDataFactory())));
         } else if (eventMarshaller != null) {
-            return eventMarshaller.marshall(event.getData());
+            Optional<OutgoingCloudEventMetadata<?>> metadata = getMetadata(event);
+            M payload = eventMarshaller.marshall(event.getData());
+            return metadata.isPresent() ? Message.of(payload, Metadata.of(metadata.orElseThrow())) : Message.of(payload);
         } else {
             throw new IllegalStateException("Not marshaller has been set for emitter " + this);
         }

--- a/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/ChannelInfo.java
+++ b/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/ChannelInfo.java
@@ -30,10 +30,13 @@ public class ChannelInfo {
     private final boolean isInput;
     private final boolean isDefault;
 
+    private final Optional<CloudEventMode> cloudEventMode;
+
     private final Optional<String> marshaller;
     private final Optional<OnOverflowInfo> onOverflow;
 
-    protected ChannelInfo(String channelName, Collection<String> triggers, String className, boolean isInput, boolean isDefault, Optional<String> marshaller, Optional<OnOverflowInfo> onOverflow) {
+    protected ChannelInfo(String channelName, Collection<String> triggers, String className, boolean isInput, boolean isDefault, Optional<String> marshaller, Optional<OnOverflowInfo> onOverflow,
+            Optional<CloudEventMode> cloudEventMode) {
         this.className = className;
         this.channelName = channelName;
         this.isInput = isInput;
@@ -41,6 +44,7 @@ public class ChannelInfo {
         this.triggers = triggers;
         this.marshaller = marshaller;
         this.onOverflow = onOverflow;
+        this.cloudEventMode = cloudEventMode;
     }
 
     public Collection<String> getTriggers() {
@@ -93,9 +97,14 @@ public class ChannelInfo {
         return onOverflow;
     }
 
+    public Optional<CloudEventMode> getCloudEventMode() {
+        return cloudEventMode;
+    }
+
     @Override
     public String toString() {
         return "ChannelInfo [channelName=" + channelName + ", className=" + className + ", triggers=" + triggers
-                + ", isInput=" + isInput + ", isDefault=" + isDefault + ", marshaller=" + marshaller + "]";
+                + ", isInput=" + isInput + ", isDefault=" + isDefault + ", cloudEventMode=" + cloudEventMode
+                + ", marshaller=" + marshaller + ", onOverflow=" + onOverflow + "]";
     }
 }

--- a/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/CloudEventMode.java
+++ b/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/CloudEventMode.java
@@ -18,18 +18,7 @@
  */
 package org.kie.kogito.addon.cloudevents.quarkus.deployment;
 
-import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.event.CloudEventMarshaller;
-import org.kie.kogito.event.EventMarshaller;
-
-public class EventEmitterGenerator extends EventGenerator {
-
-    public EventEmitterGenerator(KogitoBuildContext context, ChannelInfo channelInfo) {
-        super(context, channelInfo, "EventEmitter");
-        if (channelInfo.getCloudEventMode().filter(mode -> mode == CloudEventMode.STRUCTURED).isPresent()) {
-            generateMarshallerField("marshaller", "setCloudEventMarshaller", CloudEventMarshaller.class);
-        } else {
-            generateMarshallerField("marshaller", "setEventDataMarshaller", EventMarshaller.class);
-        }
-    }
+public enum CloudEventMode {
+    STRUCTURED,
+    BINARY
 }


### PR DESCRIPTION
Knative has issues with structure event, so we are switching to binary, by defaullt, for quarkus-http connector. 

This behaviour can be modified through configuration. 
Users can specifiy
`kogito.addon.messaging.outgoing.cloudEventMode.<channelName>=BINARY|STRUCTURED`
to configure cloud event mode per outgoing channel 
or just 
`kogito.addon.messaging.outgoing.cloudEventMode=BINARY|STRUCTURED`
to set it overrall. 
If nothing specified, binary is used for quarkus-http connector and structured for the others, to keep backward compatibility with existing examples using Kafka. 

This requires changes on kogito-apps tests https://github.com/apache/incubator-kie-kogito-apps/pull/1974 and examples https://github.com/apache/incubator-kie-kogito-examples/pull/1862

Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/3383