### PR TITLE
[Fix apache/incubator-kie-issues#987] New onError event

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/event/KogitoProcessEventSupport.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/event/KogitoProcessEventSupport.java
@@ -158,12 +158,11 @@ public interface KogitoProcessEventSupport {
             KieRuntime kruntime,
             Comment addedComment);
 
-    // 
-
     void reset();
 
     void addEventListener(KogitoProcessEventListener listener);
 
     void removeEventListener(KogitoProcessEventListener listener);
 
+    void fireOnError(KogitoProcessInstance instance, KogitoNodeInstance nodeInstance, KieRuntime kruntime, Exception exception);
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/uow/events/UnitOfWorkProcessEventListener.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/uow/events/UnitOfWorkProcessEventListener.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.uow.events;
 
+import org.kie.api.event.process.ErrorEvent;
 import org.kie.api.event.process.MessageEvent;
 import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessEvent;
@@ -59,12 +60,11 @@ public class UnitOfWorkProcessEventListener extends DefaultKogitoProcessEventLis
 
     @Override
     public void beforeProcessStarted(ProcessStartedEvent event) {
-
+        intercept(event);
     }
 
     @Override
     public void afterProcessStarted(ProcessStartedEvent event) {
-        intercept(event);
     }
 
     @Override
@@ -190,6 +190,11 @@ public class UnitOfWorkProcessEventListener extends DefaultKogitoProcessEventLis
 
     @Override
     public void onUserTaskOutputVariable(UserTaskVariableEvent event) {
+        intercept(event);
+    }
+
+    @Override
+    public void onError(ErrorEvent event) {
         intercept(event);
     }
 

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/ProcessInstanceEventBatch.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/ProcessInstanceEventBatch.java
@@ -19,13 +19,15 @@
 package org.kie.kogito.event.impl;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeSet;
 
+import org.kie.api.event.process.ErrorEvent;
 import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessEvent;
 import org.kie.api.event.process.ProcessNodeEvent;
@@ -38,7 +40,6 @@ import org.kie.api.event.usertask.UserTaskAssignmentEvent;
 import org.kie.api.event.usertask.UserTaskAttachmentEvent;
 import org.kie.api.event.usertask.UserTaskCommentEvent;
 import org.kie.api.event.usertask.UserTaskDeadlineEvent;
-import org.kie.api.event.usertask.UserTaskEvent;
 import org.kie.api.event.usertask.UserTaskStateEvent;
 import org.kie.api.event.usertask.UserTaskVariableEvent;
 import org.kie.kogito.Addons;
@@ -70,7 +71,6 @@ import org.kie.kogito.event.usertask.UserTaskInstanceVariableDataEvent;
 import org.kie.kogito.event.usertask.UserTaskInstanceVariableEventBody;
 import org.kie.kogito.internal.process.event.KogitoProcessVariableChangedEvent;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcessInstance;
@@ -86,25 +86,19 @@ public class ProcessInstanceEventBatch implements EventBatch {
     public ProcessInstanceEventBatch(String service, Addons addons) {
         this.service = service;
         this.addons = addons != null ? addons : Addons.EMTPY;
-        this.processedEvents = new ArrayList<>();
+        this.processedEvents = new TreeSet<>(new Comparator<DataEvent<?>>() {
+            @Override
+            public int compare(DataEvent<?> event1, DataEvent<?> event2) {
+                return event2 instanceof ProcessInstanceStateDataEvent &&
+                        ((ProcessInstanceStateDataEvent) event2).getData().getEventType() == ProcessInstanceStateEventBody.EVENT_TYPE_ENDED
+                        || event1 instanceof ProcessInstanceStateDataEvent &&
+                                ((ProcessInstanceStateDataEvent) event1).getData().getEventType() == ProcessInstanceStateEventBody.EVENT_TYPE_STARTED ? -1 : 1;
+            }
+        });
     }
 
     @Override
-    public void append(Object rawEvent) {
-        if (rawEvent instanceof ProcessEvent) {
-            addDataEvent((ProcessEvent) rawEvent);
-        } else if (rawEvent instanceof UserTaskEvent) {
-            addDataEvent((UserTaskEvent) rawEvent);
-        }
-    }
-
-    @Override
-    public Collection<DataEvent<?>> events() {
-        return processedEvents;
-    }
-
-    private void addDataEvent(ProcessEvent event) {
-        // process events
+    public void append(Object event) {
         if (event instanceof ProcessStartedEvent) {
             handleProcessStateEvent((ProcessStartedEvent) event);
         } else if (event instanceof ProcessCompletedEvent) {
@@ -117,7 +111,26 @@ public class ProcessInstanceEventBatch implements EventBatch {
             handleProcesssNodeEvent((SLAViolatedEvent) event);
         } else if (event instanceof ProcessVariableChangedEvent) {
             handleProcessVariableEvent((ProcessVariableChangedEvent) event);
+        } else if (event instanceof ErrorEvent) {
+            handleErrorEvent((ErrorEvent) event);
+        } else if (event instanceof UserTaskStateEvent) {
+            handleUserTaskStateEvent((UserTaskStateEvent) event);
+        } else if (event instanceof UserTaskDeadlineEvent) {
+            handleUserTaskDeadlineEvent((UserTaskDeadlineEvent) event);
+        } else if (event instanceof UserTaskAssignmentEvent) {
+            handleUserTaskAssignmentEvent((UserTaskAssignmentEvent) event);
+        } else if (event instanceof UserTaskVariableEvent) {
+            handleUserTaskVariableEvent((UserTaskVariableEvent) event);
+        } else if (event instanceof UserTaskAttachmentEvent) {
+            handleUserTaskAttachmentEvent((UserTaskAttachmentEvent) event);
+        } else if (event instanceof UserTaskCommentEvent) {
+            handleUserTaskCommentEvent((UserTaskCommentEvent) event);
         }
+    }
+
+    @Override
+    public Collection<DataEvent<?>> events() {
+        return processedEvents;
     }
 
     private void handleProcessVariableEvent(ProcessVariableChangedEvent event) {
@@ -245,52 +258,31 @@ public class ProcessInstanceEventBatch implements EventBatch {
         return piEvent;
     }
 
-    private void handleProcessStateEvent(ProcessCompletedEvent event) {
-
-        processedEvents.add(toProcessInstanceStateEvent(event, ProcessInstanceStateEventBody.EVENT_TYPE_ENDED));
-
+    private void handleErrorEvent(ErrorEvent event) {
         KogitoWorkflowProcessInstance pi = (KogitoWorkflowProcessInstance) event.getProcessInstance();
-        if (pi.getState() == KogitoProcessInstance.STATE_ERROR) {
-            ProcessInstanceErrorEventBody errorBody = ProcessInstanceErrorEventBody.create()
-                    .eventDate(new Date())
-                    .eventUser(event.getEventIdentity())
-                    .processInstanceId(pi.getId())
-                    .processId(pi.getProcessId())
-                    .processVersion(pi.getProcessVersion())
-                    .nodeDefinitionId(pi.getNodeIdInError())
-                    .nodeInstanceId(pi.getNodeInstanceIdInError())
-                    .errorMessage(pi.getErrorMessage())
-                    .build();
-            Map<String, Object> metadata = buildProcessMetadata((KogitoWorkflowProcessInstance) event.getProcessInstance());
-            ProcessInstanceErrorDataEvent piEvent =
-                    new ProcessInstanceErrorDataEvent(buildSource(event.getProcessInstance().getProcessId()), addons.toString(), event.getEventIdentity(), metadata, errorBody);
-            piEvent.setKogitoBusinessKey(pi.getBusinessKey());
-            processedEvents.add(piEvent);
-        }
+        ProcessInstanceErrorEventBody errorBody = ProcessInstanceErrorEventBody.create()
+                .eventDate(new Date())
+                .eventUser(event.getEventIdentity())
+                .processInstanceId(pi.getId())
+                .processId(pi.getProcessId())
+                .processVersion(pi.getProcessVersion())
+                .nodeDefinitionId(pi.getNodeIdInError())
+                .nodeInstanceId(pi.getNodeInstanceIdInError())
+                .errorMessage(pi.getErrorMessage())
+                .build();
+        Map<String, Object> metadata = buildProcessMetadata((KogitoWorkflowProcessInstance) event.getProcessInstance());
+        ProcessInstanceErrorDataEvent piEvent =
+                new ProcessInstanceErrorDataEvent(buildSource(event.getProcessInstance().getProcessId()), addons.toString(), event.getEventIdentity(), metadata, errorBody);
+        piEvent.setKogitoBusinessKey(pi.getBusinessKey());
+        processedEvents.add(piEvent);
+    }
+
+    private void handleProcessStateEvent(ProcessCompletedEvent event) {
+        processedEvents.add(toProcessInstanceStateEvent(event, ProcessInstanceStateEventBody.EVENT_TYPE_ENDED));
     }
 
     private void handleProcessStateEvent(ProcessStartedEvent event) {
         processedEvents.add(toProcessInstanceStateEvent(event, ProcessInstanceStateEventBody.EVENT_TYPE_STARTED));
-
-        KogitoWorkflowProcessInstance pi = (KogitoWorkflowProcessInstance) event.getProcessInstance();
-        if (pi.getState() == KogitoProcessInstance.STATE_ERROR) {
-            ProcessInstanceErrorEventBody errorBody = ProcessInstanceErrorEventBody.create()
-                    .eventDate(new Date())
-                    .eventUser(event.getEventIdentity())
-                    .processInstanceId(pi.getId())
-                    .processId(pi.getProcessId())
-                    .processVersion(pi.getProcessVersion())
-                    .nodeDefinitionId(pi.getNodeIdInError())
-                    .nodeInstanceId(pi.getNodeInstanceIdInError())
-                    .errorMessage(pi.getErrorMessage())
-                    .build();
-            Map<String, Object> metadata = buildProcessMetadata((KogitoWorkflowProcessInstance) event.getProcessInstance());
-            ProcessInstanceErrorDataEvent piEvent =
-                    new ProcessInstanceErrorDataEvent(buildSource(event.getProcessInstance().getProcessId()), addons.toString(), event.getEventIdentity(), metadata, errorBody);
-            piEvent.setKogitoBusinessKey(pi.getBusinessKey());
-            processedEvents.add(piEvent);
-        }
-
     }
 
     private ProcessInstanceStateDataEvent toProcessInstanceStateEvent(ProcessEvent event, int eventType) {
@@ -337,23 +329,6 @@ public class ProcessInstanceEventBatch implements EventBatch {
         metadata.put(ProcessInstanceEventMetadata.ROOT_PROCESS_ID_META_DATA, pi.getRootProcessId());
         metadata.put(ProcessInstanceEventMetadata.ROOT_PROCESS_INSTANCE_ID_META_DATA, pi.getRootProcessInstanceId());
         return metadata;
-    }
-
-    private void addDataEvent(UserTaskEvent event) {
-        // this should go in another event types
-        if (event instanceof UserTaskStateEvent) {
-            handleUserTaskStateEvent((UserTaskStateEvent) event);
-        } else if (event instanceof UserTaskDeadlineEvent) {
-            handleUserTaskDeadlineEvent((UserTaskDeadlineEvent) event);
-        } else if (event instanceof UserTaskAssignmentEvent) {
-            handleUserTaskAssignmentEvent((UserTaskAssignmentEvent) event);
-        } else if (event instanceof UserTaskVariableEvent) {
-            handleUserTaskVariableEvent((UserTaskVariableEvent) event);
-        } else if (event instanceof UserTaskAttachmentEvent) {
-            handleUserTaskAttachmentEvent((UserTaskAttachmentEvent) event);
-        } else if (event instanceof UserTaskCommentEvent) {
-            handleUserTaskCommentEvent((UserTaskCommentEvent) event);
-        }
     }
 
     private void handleUserTaskCommentEvent(UserTaskCommentEvent event) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/AbstractProcessNodeEvent.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/AbstractProcessNodeEvent.java
@@ -18,37 +18,28 @@
  */
 package org.jbpm.process.instance.event;
 
-import org.kie.api.event.process.SignalEvent;
+import org.kie.api.event.process.ProcessNodeEvent;
 import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.ProcessInstance;
 
-public class SignalEventImpl extends AbstractProcessNodeEvent implements SignalEvent {
+public abstract class AbstractProcessNodeEvent extends ProcessEvent implements ProcessNodeEvent {
 
-    private static final long serialVersionUID = 1L;
-    private final String signalName;
-    private final Object signalObject;
+    private final NodeInstance nodeInstance;
 
-    public SignalEventImpl(ProcessInstance instance, KieRuntime kruntime, NodeInstance nodeInstance,
-            String signalName, Object signalObject, String identity) {
-        super(nodeInstance, instance, kruntime, identity);
-        this.signalName = signalName;
-        this.signalObject = signalObject;
+    protected AbstractProcessNodeEvent(NodeInstance nodeInstance, ProcessInstance instance, KieRuntime kruntime) {
+        super(instance, kruntime);
+        this.nodeInstance = nodeInstance;
+    }
+
+    protected AbstractProcessNodeEvent(NodeInstance nodeInstance, ProcessInstance instance, KieRuntime kruntime, String identity) {
+        super(instance, kruntime, identity);
+        this.nodeInstance = nodeInstance;
     }
 
     @Override
-    public String getSignalName() {
-        return signalName;
+    public NodeInstance getNodeInstance() {
+        return nodeInstance;
     }
 
-    @Override
-    public Object getSignal() {
-        return signalObject;
-    }
-
-    @Override
-    public String toString() {
-        return "SignalEventImpl [nodeInstance=" + getNodeInstance() + ", signalName=" + signalName + ", signalObject=" +
-                signalObject + "]";
-    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/ErrorEventImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/ErrorEventImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jbpm.process.instance.event;
+
+import org.kie.api.event.process.ErrorEvent;
+import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessInstance;
+
+public class ErrorEventImpl extends ProcessEvent implements ErrorEvent {
+
+    private static final long serialVersionUID = 1L;
+    private final NodeInstance nodeInstance;
+    private final Exception exception;
+
+    public ErrorEventImpl(ProcessInstance instance, KieRuntime kruntime, NodeInstance nodeInstance,
+            Exception exception) {
+        super(instance, kruntime);
+        this.nodeInstance = nodeInstance;
+        this.exception = exception;
+    }
+
+    @Override
+    public NodeInstance getNodeInstance() {
+        return nodeInstance;
+    }
+
+    @Override
+    public Exception getException() {
+        return exception;
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorEventImpl [nodeInstance=" + nodeInstance + ", exception=" + exception + "]";
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/ErrorEventImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/ErrorEventImpl.java
@@ -23,22 +23,15 @@ import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.ProcessInstance;
 
-public class ErrorEventImpl extends ProcessEvent implements ErrorEvent {
+public class ErrorEventImpl extends AbstractProcessNodeEvent implements ErrorEvent {
 
     private static final long serialVersionUID = 1L;
-    private final NodeInstance nodeInstance;
     private final Exception exception;
 
     public ErrorEventImpl(ProcessInstance instance, KieRuntime kruntime, NodeInstance nodeInstance,
             Exception exception) {
-        super(instance, kruntime);
-        this.nodeInstance = nodeInstance;
+        super(nodeInstance, instance, kruntime);
         this.exception = exception;
-    }
-
-    @Override
-    public NodeInstance getNodeInstance() {
-        return nodeInstance;
     }
 
     @Override
@@ -48,6 +41,6 @@ public class ErrorEventImpl extends ProcessEvent implements ErrorEvent {
 
     @Override
     public String toString() {
-        return "ErrorEventImpl [nodeInstance=" + nodeInstance + ", exception=" + exception + "]";
+        return "ErrorEventImpl [nodeInstance=" + getNodeInstance() + ", exception=" + exception + "]";
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/KogitoProcessEventSupportImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/KogitoProcessEventSupportImpl.java
@@ -367,4 +367,10 @@ public class KogitoProcessEventSupportImpl implements KogitoProcessEventSupport 
         this.clear();
     }
 
+    @Override
+    public void fireOnError(KogitoProcessInstance instance, KogitoNodeInstance nodeInstance, KieRuntime kruntime, Exception exception) {
+        ErrorEventImpl event = new ErrorEventImpl(instance, kruntime, nodeInstance, exception);
+        notifyAllListeners(l -> l.onError(event));
+    }
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/KogitoProcessNodeLeftEventImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/KogitoProcessNodeLeftEventImpl.java
@@ -23,24 +23,17 @@ import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 
-public class KogitoProcessNodeLeftEventImpl extends ProcessEvent implements ProcessNodeLeftEvent {
+public class KogitoProcessNodeLeftEventImpl extends AbstractProcessNodeEvent implements ProcessNodeLeftEvent {
 
     private static final long serialVersionUID = 510l;
 
-    private NodeInstance nodeInstance;
-
     public KogitoProcessNodeLeftEventImpl(NodeInstance nodeInstance, KieRuntime kruntime, String identity) {
-        super(nodeInstance.getProcessInstance(), kruntime, identity);
-        this.nodeInstance = nodeInstance;
-    }
-
-    public NodeInstance getNodeInstance() {
-        return nodeInstance;
+        super(nodeInstance, nodeInstance.getProcessInstance(), kruntime, identity);
     }
 
     @Override
     public String toString() {
-        return "==>[ProcessNodeLeft(nodeId=" + nodeInstance.getNodeId() + "; id=" + ((KogitoNodeInstance) nodeInstance).getStringId()
+        return "==>[ProcessNodeLeft(nodeId=" + getNodeInstance().getNodeId() + "; id=" + ((KogitoNodeInstance) getNodeInstance()).getStringId()
                 + "; nodeName=" + getNodeInstance().getNodeName() + "; processName=" + getProcessInstance().getProcessName() + "; processId=" + getProcessInstance().getProcessId() + ")]";
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/KogitoProcessNodeTriggeredEventImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/KogitoProcessNodeTriggeredEventImpl.java
@@ -23,24 +23,18 @@ import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 
-public class KogitoProcessNodeTriggeredEventImpl extends ProcessEvent implements ProcessNodeTriggeredEvent {
+public class KogitoProcessNodeTriggeredEventImpl extends AbstractProcessNodeEvent implements ProcessNodeTriggeredEvent {
 
     private static final long serialVersionUID = 510l;
 
-    private NodeInstance nodeInstance;
-
     public KogitoProcessNodeTriggeredEventImpl(NodeInstance nodeInstance, KieRuntime kruntime, String identity) {
-        super(nodeInstance.getProcessInstance(), kruntime, identity);
-        this.nodeInstance = nodeInstance;
-    }
+        super(nodeInstance, nodeInstance.getProcessInstance(), kruntime, identity);
 
-    public NodeInstance getNodeInstance() {
-        return nodeInstance;
     }
 
     @Override
     public String toString() {
-        return "==>[ProcessNodeTriggered(nodeId=" + nodeInstance.getNodeId() + "; id=" + ((KogitoNodeInstance) nodeInstance).getStringId()
+        return "==>[ProcessNodeTriggered(nodeId=" + getNodeInstance().getNodeId() + "; id=" + ((KogitoNodeInstance) getNodeInstance()).getStringId()
                 + "; nodeName=" + getNodeInstance().getNodeName() + "; processName=" + getProcessInstance().getProcessName() + "; processId=" + getProcessInstance().getProcessId() + ")]";
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/MessageEventImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/MessageEventImpl.java
@@ -23,24 +23,17 @@ import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.ProcessInstance;
 
-public class MessageEventImpl extends ProcessEvent implements MessageEvent {
+public class MessageEventImpl extends AbstractProcessNodeEvent implements MessageEvent {
 
     private static final long serialVersionUID = 1L;
-    private NodeInstance nodeInstance;
-    private String messageName;
-    private Object messageObject;
+    private final String messageName;
+    private final Object messageObject;
 
     public MessageEventImpl(ProcessInstance instance, KieRuntime kruntime, NodeInstance nodeInstance,
             String messageName, Object messageObject, String identity) {
-        super(instance, kruntime, identity);
-        this.nodeInstance = nodeInstance;
+        super(nodeInstance, instance, kruntime, identity);
         this.messageName = messageName;
         this.messageObject = messageObject;
-    }
-
-    @Override
-    public NodeInstance getNodeInstance() {
-        return nodeInstance;
     }
 
     @Override
@@ -55,7 +48,7 @@ public class MessageEventImpl extends ProcessEvent implements MessageEvent {
 
     @Override
     public String toString() {
-        return "MessageEventImpl [nodeInstance=" + nodeInstance + ", messageName=" + messageName + ", messageObject=" +
+        return "MessageEventImpl [nodeInstance=" + getNodeInstance() + ", messageName=" + messageName + ", messageObject=" +
                 messageObject + "]";
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -1149,6 +1149,7 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
         this.errorMessage = rootException.getClass().getCanonicalName() + " - " + rootException.getMessage();
         setState(STATE_ERROR);
         logger.error("Unexpected error while executing node {} in process instance {}", nodeInstanceInError.getNode().getName(), this.getStringId(), e);
+        ((InternalProcessRuntime) getKnowledgeRuntime().getProcessRuntime()).getProcessEventSupport().fireOnError(this, nodeInstanceInError, getKnowledgeRuntime(), e);
         // remove node instance that caused an error
         ((org.jbpm.workflow.instance.NodeInstanceContainer) nodeInstanceInError.getNodeInstanceContainer()).removeNodeInstance(nodeInstanceInError);
     }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/987
Ensure that starting event is the first one and complete process events is the last one
Unlink error event from state event so, if there is an error is published always and not only if it happens in the sync part of the process. 
Merge with https://github.com/apache/incubator-kie-drools/pull/5766 and https://github.com/apache/incubator-kie-kogito-apps/pull/2011