### PR TITLE
[Fix #3390] Process is not completed when node is retriggered (but end node is executed)

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/NodeInstanceContainer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/NodeInstanceContainer.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import org.jbpm.workflow.core.node.AsyncEventNode;
 import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.NodeContainer;
+import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstanceContainer;
 
 import static org.jbpm.ruleflow.core.Metadata.CUSTOM_ASYNC;
@@ -64,7 +65,12 @@ public interface NodeInstanceContainer extends KogitoNodeInstanceContainer {
 
             if (nodeDefinitionId.equals(node.getMetaData().get(UNIQUE_ID))) {
                 if (nodeContainer instanceof Node) {
-                    return ((NodeInstanceContainer) getNodeInstance((Node) nodeContainer)).getNodeInstance(node);
+                    Collection<KogitoNodeInstance> nodeInstances = getKogitoNodeInstances(ni -> ni.getNode().getId() == (((Node) nodeContainer).getId()), true);
+                    if (nodeInstances.isEmpty()) {
+                        return ((NodeInstanceContainer) getNodeInstance((Node) nodeContainer)).getNodeInstance(node);
+                    } else {
+                        return ((NodeInstanceContainer) nodeInstances.iterator().next()).getNodeInstance(node);
+                    }
                 } else {
                     return getNodeInstance(node);
                 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RetriggerIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RetriggerIT.java
@@ -53,6 +53,12 @@ class RetriggerIT {
                 .accept(ContentType.JSON).when()
                 .post("/management/processes/division/instances/{id}/retrigger", id)
                 .then().statusCode(200).body("workflowdata.response", is(2));
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON).when()
+                .get("/division/{id}", id)
+                .then().statusCode(404);
     }
 
 }


### PR DESCRIPTION
Calling getNodeInstance over containernode creates another instance, hence the previous node container instance is there when the engine checks if the process can be completed (so it does not complete it) 
Therefore, as an alternative, a existing instance with that node id is searched, if found, that is the parent container instance where to recreate the node instance to be retriggered. If not found, we call getNodeInstance over the container node. 

