### PR TITLE
[Fix #3436] Ignoring unknown properties

### DIFF
--- a/addons/common/marshallers/avro/pom.xml
+++ b/addons/common/marshallers/avro/pom.xml
@@ -72,5 +72,29 @@
     </dependency>
 
   </dependencies>
-
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>${version.org.apache.avro}</version>
+        <executions>
+          <execution>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>schema</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/test/avro/</sourceDirectory>
+              <fieldVisibility>PRIVATE</fieldVisibility>
+              <includes>
+                <include>**/*.avsc</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+       </plugin>
+    </plugins>
+  </build>
 </project>

--- a/addons/common/marshallers/avro/src/main/java/org/kie/kogito/event/avro/AvroIO.java
+++ b/addons/common/marshallers/avro/src/main/java/org/kie/kogito/event/avro/AvroIO.java
@@ -167,6 +167,7 @@ public class AvroIO {
 
     private static final AvroMapper getAvroMapper() {
         AvroMapper mapper = new AvroMapper();
+        mapper.configure(JsonGenerator.Feature.IGNORE_UNKNOWN, true);
         mapper.findAndRegisterModules().registerModule(new SimpleModule().addSerializer(Utf8.class, new JsonSerializer<Utf8>() {
             @Override
             public void serialize(Utf8 value, JsonGenerator gen, SerializerProvider serializers) throws IOException {

--- a/addons/common/marshallers/avro/src/test/avro/pojo.avsc
+++ b/addons/common/marshallers/avro/src/test/avro/pojo.avsc
@@ -1,0 +1,18 @@
+{
+  "namespace": "org.kie.kogito.event.avro",
+  "type": "record",
+  "name": "Person",
+  "fields": [
+    {
+      "name": "name",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "age",
+      "type": "int"
+    }
+  ]
+}

--- a/addons/common/marshallers/avro/src/test/java/org/kie/kogito/event/avro/AvroMarshallUnmarshallTest.java
+++ b/addons/common/marshallers/avro/src/test/java/org/kie/kogito/event/avro/AvroMarshallUnmarshallTest.java
@@ -61,4 +61,9 @@ class AvroMarshallUnmarshallTest {
     void testJsonNodeCloudEventMarshaller() throws IOException {
         testCloudEventMarshalling(getJsonNodeCloudEvent(), JsonNode.class, new AvroCloudEventMarshaller(avroUtils), new AvroCloudEventUnmarshallerFactory(avroUtils));
     }
+
+    @Test
+    void testGeneratedPojoMarshaller() throws IOException {
+        testEventMarshalling(Person.newBuilder().setAge(0).setName("Pepe").build(), new AvroEventMarshaller(avroUtils), new AvroEventUnmarshaller(avroUtils));
+    }
 }

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -98,7 +98,8 @@
     <version.org.mozilla.rhino>1.7.13</version.org.mozilla.rhino>
     <version.org.redis>2.0.4</version.org.redis>
     <version.org.postgres>13.4-alpine3.14</version.org.postgres>
-
+    <!-- we align to version used by quarkus -->
+    <version.org.apache.avro>1.11.3</version.org.apache.avro>
     <version.org.assertj>3.22.0</version.org.assertj>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
@@ -296,6 +297,11 @@
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-avro</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${version.org.apache.avro}</version>
       </dependency>
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
The issue is caused because quarkus-avro uses 1.11.1 version (for quarkus2) or 1.11.3 (for quarkus 3) of apache avro and jackson-avro uses version 1.8.4. 
When using avro generator Version > 1.9, it adds an additional field which makes jackson serializer fails. 
Configuring mapper to ignore unknown properties do the trick. 
Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/3436