### PR TITLE
incubator-kie-kogito-runtimes#3438: check if resources folder path exists

### DIFF
--- a/quarkus/addons/source-files/deployment/src/main/java/org/kie/kogito/addon/source/files/deployment/KogitoAddOnSourceFilesProcessor.java
+++ b/quarkus/addons/source-files/deployment/src/main/java/org/kie/kogito/addon/source/files/deployment/KogitoAddOnSourceFilesProcessor.java
@@ -87,11 +87,13 @@ class KogitoAddOnSourceFilesProcessor extends OneOfCapabilityKogitoAddOnProcesso
 
         for (File resourceFile : resourcePaths) {
             Path resourcePath = resourceFile.toPath();
-            try (Stream<Path> walkedPaths = Files.walk(resourcePath)) {
-                walkedPaths.filter(this::isSourceFile)
-                        .map(resourcePath::relativize)
-                        .map(Path::toString)
-                        .forEach(sourceFiles::add);
+            if (Files.exists(resourcePath)) {
+                try (Stream<Path> walkedPaths = Files.walk(resourcePath)) {
+                    walkedPaths.filter(this::isSourceFile)
+                            .map(resourcePath::relativize)
+                            .map(Path::toString)
+                            .forEach(sourceFiles::add);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes
*  apache/incubator-kie-kogito-runtimes#3438

Check if the resources folder exists before trying to walk it in source files addon.

This has started failing native builds after 
* apache/incubator-kie-issues#847