### PR TITLE
[Fix #3453] Setting overflow strategy to unbounded for process events

### DIFF
--- a/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/process/ReactiveMessagingEventPublisher.java
+++ b/quarkus/addons/events/process/runtime/src/main/java/org/kie/kogito/events/process/ReactiveMessagingEventPublisher.java
@@ -25,6 +25,8 @@ import java.util.function.BiConsumer;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow.Strategy;
 import org.kie.kogito.addon.quarkus.common.reactive.messaging.MessageDecoratorProvider;
 import org.kie.kogito.event.DataEvent;
 import org.kie.kogito.event.EventPublisher;
@@ -52,6 +54,7 @@ public class ReactiveMessagingEventPublisher implements EventPublisher {
 
     @Inject
     @Channel(PROCESS_INSTANCES_TOPIC_NAME)
+    @OnOverflow(Strategy.UNBOUNDED_BUFFER)
     MutinyEmitter<String> processInstancesEventsEmitter;
     private BiConsumer<MutinyEmitter<String>, Message<String>> processInstanceConsumer;
 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/3453
Unfortunately OnOverflow annotation requires contant value, so this cannot be make configurable without code generation. Therefore I just changed overflow strategy to unbounded. 