### PR TITLE
[Fix #3456]Support multiple constraint over same connection

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/feel/FeelProcessValidator.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/feel/FeelProcessValidator.java
@@ -19,6 +19,7 @@
 package org.jbpm.bpmn2.feel;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -63,15 +64,17 @@ public class FeelProcessValidator extends RuleFlowProcessValidator {
         Arrays.stream(nodes).filter(n -> n instanceof Split).forEach(node -> {
             final Split split = (Split) node;
             if (split.getType() == Split.TYPE_XOR || split.getType() == Split.TYPE_OR) {
-                for (Map.Entry<ConnectionRef, Constraint> entry : split.getConstraints().entrySet()) {
-                    if (entry.getValue() != null && "FEEL".equals(entry.getValue().getDialect())) {
-                        try {
-                            verifyFEELbyCompilingExpression(process.getVariableScope(), entry.getValue().getConstraint());
-                        } catch (FeelCompilationException ex) {
-                            addErrorMessage(process,
-                                    node,
-                                    errors,
-                                    format("Invalid FEEL expression: '%s'.", entry.getValue().getConstraint()));
+                for (Map.Entry<ConnectionRef, Collection<Constraint>> entry : split.getConstraints().entrySet()) {
+                    for (Constraint constraint : entry.getValue()) {
+                        if (constraint != null && "FEEL".equals(constraint.getDialect())) {
+                            try {
+                                verifyFEELbyCompilingExpression(process.getVariableScope(), constraint.getConstraint());
+                            } catch (FeelCompilationException ex) {
+                                addErrorMessage(process,
+                                        node,
+                                        errors,
+                                        format("Invalid FEEL expression: '%s'.", constraint.getConstraint()));
+                            }
                         }
                     }
                 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SplitHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SplitHandler.java
@@ -18,6 +18,7 @@
  */
 package org.jbpm.bpmn2.xml;
 
+import java.util.Collection;
 import java.util.Map;
 
 import org.jbpm.workflow.core.Constraint;
@@ -48,26 +49,30 @@ public class SplitHandler extends AbstractNodeHandler {
             case Split.TYPE_XOR:
                 type = "exclusiveGateway";
                 writeNode(type, node, xmlDump, metaDataType);
-                for (Map.Entry<ConnectionRef, Constraint> entry : split.getConstraints().entrySet()) {
-                    if (entry.getValue() != null && entry.getValue().isDefault()) {
-                        xmlDump.append("default=\"" +
-                                XmlBPMNProcessDumper.getUniqueNodeId(split) + "-" +
-                                XmlBPMNProcessDumper.getUniqueNodeId(node.getParentContainer().getNode(entry.getKey().getNodeId())) +
-                                "\" ");
-                        break;
+                for (Map.Entry<ConnectionRef, Collection<Constraint>> entry : split.getConstraints().entrySet()) {
+                    for (Constraint constraint : entry.getValue()) {
+                        if (constraint != null && constraint.isDefault()) {
+                            xmlDump.append("default=\"" +
+                                    XmlBPMNProcessDumper.getUniqueNodeId(split) + "-" +
+                                    XmlBPMNProcessDumper.getUniqueNodeId(node.getParentContainer().getNode(entry.getKey().getNodeId())) +
+                                    "\" ");
+                            break;
+                        }
                     }
                 }
                 break;
             case Split.TYPE_OR:
                 type = "inclusiveGateway";
                 writeNode(type, node, xmlDump, metaDataType);
-                for (Map.Entry<ConnectionRef, Constraint> entry : split.getConstraints().entrySet()) {
-                    if (entry.getValue() != null && entry.getValue().isDefault()) {
-                        xmlDump.append("default=\"" +
-                                XmlBPMNProcessDumper.getUniqueNodeId(split) + "-" +
-                                XmlBPMNProcessDumper.getUniqueNodeId(node.getParentContainer().getNode(entry.getKey().getNodeId())) +
-                                "\" ");
-                        break;
+                for (Map.Entry<ConnectionRef, Collection<Constraint>> entry : split.getConstraints().entrySet()) {
+                    for (Constraint constraint : entry.getValue()) {
+                        if (constraint != null && constraint.isDefault()) {
+                            xmlDump.append("default=\"" +
+                                    XmlBPMNProcessDumper.getUniqueNodeId(split) + "-" +
+                                    XmlBPMNProcessDumper.getUniqueNodeId(node.getParentContainer().getNode(entry.getKey().getNodeId())) +
+                                    "\" ");
+                            break;
+                        }
                     }
                 }
                 break;

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
@@ -759,35 +759,39 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
         if (connection.getFrom() instanceof Split) {
             Split split = (Split) connection.getFrom();
             if (split.getType() == Split.TYPE_XOR || split.getType() == Split.TYPE_OR) {
-                Constraint constraint = split.getConstraint(connection);
-                if (constraint == null) {
+                Collection<Constraint> constraints = split.getConstraint(connection);
+                if (constraints == null) {
                     xmlDump.append(">" + EOL +
                             "      <conditionExpression xsi:type=\"tFormalExpression\" />");
                 } else {
-                    if (constraint.getName() != null && constraint.getName().trim().length() > 0) {
-                        xmlDump.append("name=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(constraint.getName()) + "\" ");
-                    }
-                    if (constraint.getPriority() != 0) {
-                        xmlDump.append("tns:priority=\"" + constraint.getPriority() + "\" ");
-                    }
-                    xmlDump.append(">" + EOL +
-                            "      <conditionExpression xsi:type=\"tFormalExpression\" ");
-                    if ("code".equals(constraint.getType())) {
-                        if (JavaDialect.ID.equals(constraint.getDialect())) {
-                            xmlDump.append("language=\"" + JAVA_LANGUAGE + "\" ");
-                        } else if ("XPath".equals(constraint.getDialect())) {
-                            xmlDump.append("language=\"" + XPATH_LANGUAGE + "\" ");
-                        } else if ("FEEL".equals(constraint.getDialect())) {
-                            xmlDump.append("language=\"" + FEEL_LANGUAGE + "\" ");
+                    for (Constraint constraint : constraints) {
+                        if (constraint != null) {
+                            if (constraint.getName() != null && constraint.getName().trim().length() > 0) {
+                                xmlDump.append("name=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(constraint.getName()) + "\" ");
+                            }
+                            if (constraint.getPriority() != 0) {
+                                xmlDump.append("tns:priority=\"" + constraint.getPriority() + "\" ");
+                            }
+                            xmlDump.append(">" + EOL +
+                                    "      <conditionExpression xsi:type=\"tFormalExpression\" ");
+                            if ("code".equals(constraint.getType())) {
+                                if (JavaDialect.ID.equals(constraint.getDialect())) {
+                                    xmlDump.append("language=\"" + JAVA_LANGUAGE + "\" ");
+                                } else if ("XPath".equals(constraint.getDialect())) {
+                                    xmlDump.append("language=\"" + XPATH_LANGUAGE + "\" ");
+                                } else if ("FEEL".equals(constraint.getDialect())) {
+                                    xmlDump.append("language=\"" + FEEL_LANGUAGE + "\" ");
+                                }
+                            } else {
+                                xmlDump.append("language=\"" + RULE_LANGUAGE + "\" ");
+                            }
+                            String constraintString = constraint.getConstraint();
+                            if (constraintString == null) {
+                                constraintString = "";
+                            }
+                            xmlDump.append(">" + XmlDumper.replaceIllegalChars(constraintString) + "</conditionExpression>");
                         }
-                    } else {
-                        xmlDump.append("language=\"" + RULE_LANGUAGE + "\" ");
                     }
-                    String constraintString = constraint.getConstraint();
-                    if (constraintString == null) {
-                        constraintString = "";
-                    }
-                    xmlDump.append(">" + XmlDumper.replaceIllegalChars(constraintString) + "</conditionExpression>");
                 }
                 xmlDump.append(EOL
                         + "    </sequenceFlow>" + EOL);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
@@ -759,39 +759,35 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
         if (connection.getFrom() instanceof Split) {
             Split split = (Split) connection.getFrom();
             if (split.getType() == Split.TYPE_XOR || split.getType() == Split.TYPE_OR) {
-                Collection<Constraint> constraints = split.getConstraint(connection);
-                if (constraints == null) {
+                Constraint constraint = split.getConstraint(connection);
+                if (constraint == null) {
                     xmlDump.append(">" + EOL +
                             "      <conditionExpression xsi:type=\"tFormalExpression\" />");
                 } else {
-                    for (Constraint constraint : constraints) {
-                        if (constraint != null) {
-                            if (constraint.getName() != null && constraint.getName().trim().length() > 0) {
-                                xmlDump.append("name=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(constraint.getName()) + "\" ");
-                            }
-                            if (constraint.getPriority() != 0) {
-                                xmlDump.append("tns:priority=\"" + constraint.getPriority() + "\" ");
-                            }
-                            xmlDump.append(">" + EOL +
-                                    "      <conditionExpression xsi:type=\"tFormalExpression\" ");
-                            if ("code".equals(constraint.getType())) {
-                                if (JavaDialect.ID.equals(constraint.getDialect())) {
-                                    xmlDump.append("language=\"" + JAVA_LANGUAGE + "\" ");
-                                } else if ("XPath".equals(constraint.getDialect())) {
-                                    xmlDump.append("language=\"" + XPATH_LANGUAGE + "\" ");
-                                } else if ("FEEL".equals(constraint.getDialect())) {
-                                    xmlDump.append("language=\"" + FEEL_LANGUAGE + "\" ");
-                                }
-                            } else {
-                                xmlDump.append("language=\"" + RULE_LANGUAGE + "\" ");
-                            }
-                            String constraintString = constraint.getConstraint();
-                            if (constraintString == null) {
-                                constraintString = "";
-                            }
-                            xmlDump.append(">" + XmlDumper.replaceIllegalChars(constraintString) + "</conditionExpression>");
-                        }
+                    if (constraint.getName() != null && constraint.getName().trim().length() > 0) {
+                        xmlDump.append("name=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(constraint.getName()) + "\" ");
                     }
+                    if (constraint.getPriority() != 0) {
+                        xmlDump.append("tns:priority=\"" + constraint.getPriority() + "\" ");
+                    }
+                    xmlDump.append(">" + EOL +
+                            "      <conditionExpression xsi:type=\"tFormalExpression\" ");
+                    if ("code".equals(constraint.getType())) {
+                        if (JavaDialect.ID.equals(constraint.getDialect())) {
+                            xmlDump.append("language=\"" + JAVA_LANGUAGE + "\" ");
+                        } else if ("XPath".equals(constraint.getDialect())) {
+                            xmlDump.append("language=\"" + XPATH_LANGUAGE + "\" ");
+                        } else if ("FEEL".equals(constraint.getDialect())) {
+                            xmlDump.append("language=\"" + FEEL_LANGUAGE + "\" ");
+                        }
+                    } else {
+                        xmlDump.append("language=\"" + RULE_LANGUAGE + "\" ");
+                    }
+                    String constraintString = constraint.getConstraint();
+                    if (constraintString == null) {
+                        constraintString = "";
+                    }
+                    xmlDump.append(">" + XmlDumper.replaceIllegalChars(constraintString) + "</conditionExpression>");
                 }
                 xmlDump.append(EOL
                         + "    </sequenceFlow>" + EOL);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
@@ -331,7 +331,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 Split split = (Split) nodes[i];
                 if (split.getType() == Split.TYPE_XOR || split.getType() == Split.TYPE_OR) {
                     for (Connection connection : split.getDefaultOutgoingConnections()) {
-                        Collection<Constraint> constraints = split.getConstraint(connection);
+                        Collection<Constraint> constraints = split.getConstraints(connection);
                         if (constraints != null) {
                             for (Constraint constraint : constraints)
                                 if (constraint != null && "rule".equals(constraint.getType())) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/SplitNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/SplitNodeVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.jbpm.compiler.canonical;
 
+import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.function.Supplier;
 
@@ -61,45 +62,49 @@ public class SplitNodeVisitor extends AbstractNodeVisitor<Split> {
         visitMetaData(node.getMetaData(), body, getNodeId(node));
 
         if (node.getType() == Split.TYPE_OR || node.getType() == Split.TYPE_XOR) {
-            for (Entry<ConnectionRef, Constraint> entry : node.getConstraints().entrySet()) {
+            for (Entry<ConnectionRef, Collection<Constraint>> entry : node.getConstraints().entrySet()) {
                 if (entry.getValue() != null) {
-                    Expression returnValueEvaluator;
-                    if (entry.getValue() instanceof ReturnValueConstraintEvaluator && ((ReturnValueConstraintEvaluator) entry.getValue()).getReturnValueEvaluator() instanceof Supplier) {
-                        returnValueEvaluator = ((Supplier<Expression>) ((ReturnValueConstraintEvaluator) entry.getValue()).getReturnValueEvaluator()).get();
-                    } else if ("FEEL".equals(entry.getValue().getDialect())) {
-                        returnValueEvaluator = buildFEELReturnValueEvaluator(entry);
-                    } else {
-                        BlockStmt actionBody = new BlockStmt();
-                        LambdaExpr lambda = new LambdaExpr(
-                                new Parameter(new UnknownType(), KCONTEXT_VAR), // (kcontext) ->
-                                actionBody);
+                    for (Constraint constraint : entry.getValue()) {
+                        if (constraint != null) {
+                            Expression returnValueEvaluator;
+                            if (constraint instanceof ReturnValueConstraintEvaluator && ((ReturnValueConstraintEvaluator) constraint).getReturnValueEvaluator() instanceof Supplier) {
+                                returnValueEvaluator = ((Supplier<Expression>) ((ReturnValueConstraintEvaluator) constraint).getReturnValueEvaluator()).get();
+                            } else if ("FEEL".equals(constraint.getDialect())) {
+                                returnValueEvaluator = buildFEELReturnValueEvaluator(constraint);
+                            } else {
+                                BlockStmt actionBody = new BlockStmt();
+                                LambdaExpr lambda = new LambdaExpr(
+                                        new Parameter(new UnknownType(), KCONTEXT_VAR), // (kcontext) ->
+                                        actionBody);
 
-                        for (Variable v : variableScope.getVariables()) {
-                            actionBody.addStatement(makeAssignment(v));
+                                for (Variable v : variableScope.getVariables()) {
+                                    actionBody.addStatement(makeAssignment(v));
+                                }
+
+                                BlockStmt blockStmt = StaticJavaParser.parseBlock("{" + constraint.getConstraint() + "}");
+                                blockStmt.getStatements().forEach(actionBody::addStatement);
+
+                                returnValueEvaluator = lambda;
+                            }
+                            body.addStatement(getFactoryMethod(getNodeId(node), METHOD_CONSTRAINT,
+                                    new LongLiteralExpr(entry.getKey().getNodeId()),
+                                    new StringLiteralExpr(getOrDefault(entry.getKey().getConnectionId(), "")),
+                                    new StringLiteralExpr(entry.getKey().getToType()),
+                                    new StringLiteralExpr(constraint.getDialect()),
+                                    returnValueEvaluator,
+                                    new IntegerLiteralExpr(constraint.getPriority()),
+                                    new BooleanLiteralExpr(constraint.isDefault())));
                         }
-
-                        BlockStmt blockStmt = StaticJavaParser.parseBlock("{" + entry.getValue().getConstraint() + "}");
-                        blockStmt.getStatements().forEach(actionBody::addStatement);
-
-                        returnValueEvaluator = lambda;
                     }
-                    body.addStatement(getFactoryMethod(getNodeId(node), METHOD_CONSTRAINT,
-                            new LongLiteralExpr(entry.getKey().getNodeId()),
-                            new StringLiteralExpr(getOrDefault(entry.getKey().getConnectionId(), "")),
-                            new StringLiteralExpr(entry.getKey().getToType()),
-                            new StringLiteralExpr(entry.getValue().getDialect()),
-                            returnValueEvaluator,
-                            new IntegerLiteralExpr(entry.getValue().getPriority()),
-                            new BooleanLiteralExpr(entry.getValue().isDefault())));
                 }
             }
         }
         body.addStatement(getDoneMethod(getNodeId(node)));
     }
 
-    public static ObjectCreationExpr buildFEELReturnValueEvaluator(Entry<ConnectionRef, Constraint> entry) {
+    private static ObjectCreationExpr buildFEELReturnValueEvaluator(Constraint constraint) {
         return new ObjectCreationExpr(null,
                 StaticJavaParser.parseClassOrInterfaceType("org.jbpm.bpmn2.feel.FeelReturnValueEvaluator"),
-                new NodeList<>(new StringLiteralExpr(entry.getValue().getConstraint())));
+                new NodeList<>(new StringLiteralExpr(constraint.getConstraint())));
     }
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/MultiConditionalSequenceFlowNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/MultiConditionalSequenceFlowNodeBuilder.java
@@ -18,8 +18,9 @@
  */
 package org.jbpm.process.builder;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 
 import org.drools.drl.ast.descr.ProcessDescr;
@@ -30,7 +31,6 @@ import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
 import org.jbpm.process.instance.impl.RuleConstraintEvaluator;
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.impl.ConnectionRef;
-import org.jbpm.workflow.core.impl.ConstraintImpl;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.Split;
 import org.kie.api.definition.process.Connection;
@@ -42,19 +42,16 @@ public class MultiConditionalSequenceFlowNodeBuilder implements ProcessNodeBuild
     public void build(Process process, ProcessDescr processDescr,
             ProcessBuildContext context, Node node) {
 
-        Map<ConnectionRef, Constraint> constraints = ((NodeImpl) node).getConstraints();
-
         // exclude split as it is handled with separate builder and nodes with non conditional sequence flows
-        if (node instanceof Split || constraints.size() == 0) {
+        if (node instanceof Split) {
             return;
         }
 
         // we need to clone the map, so we can update the original while iterating.
-        Map<ConnectionRef, Constraint> map = new HashMap<>(constraints);
-        for (Iterator<Map.Entry<ConnectionRef, Constraint>> it = map.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<ConnectionRef, Constraint> entry = it.next();
+        for (Iterator<Map.Entry<ConnectionRef, Collection<Constraint>>> it = ((NodeImpl) node).getConstraints().entrySet().iterator(); it.hasNext();) {
+            Map.Entry<ConnectionRef, Collection<Constraint>> entry = it.next();
             ConnectionRef connection = entry.getKey();
-            ConstraintImpl constraint = (ConstraintImpl) entry.getValue();
+            Collection<Constraint> constraints = new LinkedList<>(entry.getValue());
             Connection outgoingConnection = null;
             for (Connection out : ((NodeImpl) node).getDefaultOutgoingConnections()) {
                 if (out.getToType().equals(connection.getToType())
@@ -65,27 +62,31 @@ public class MultiConditionalSequenceFlowNodeBuilder implements ProcessNodeBuild
             if (outgoingConnection == null) {
                 throw new IllegalArgumentException("Could not find outgoing connection");
             }
-            if ("rule".equals(constraint.getType())) {
-                RuleConstraintEvaluator ruleConstraint = new RuleConstraintEvaluator();
-                ruleConstraint.setDialect(constraint.getDialect());
-                ruleConstraint.setName(constraint.getName());
-                ruleConstraint.setPriority(constraint.getPriority());
-                ruleConstraint.setDefault(constraint.isDefault());
-                ((NodeImpl) node).setConstraint(outgoingConnection, ruleConstraint);
-            } else if ("code".equals(constraint.getType())) {
-                ReturnValueConstraintEvaluator returnValueConstraint = new ReturnValueConstraintEvaluator();
-                returnValueConstraint.setDialect(constraint.getDialect());
-                returnValueConstraint.setName(constraint.getName());
-                returnValueConstraint.setPriority(constraint.getPriority());
-                returnValueConstraint.setDefault(constraint.isDefault());
-                ((NodeImpl) node).setConstraint(outgoingConnection, returnValueConstraint);
+            for (Constraint constraint : constraints) {
+                if (constraint != null) {
+                    if ("rule".equals(constraint.getType())) {
+                        RuleConstraintEvaluator ruleConstraint = new RuleConstraintEvaluator();
+                        ruleConstraint.setDialect(constraint.getDialect());
+                        ruleConstraint.setName(constraint.getName());
+                        ruleConstraint.setPriority(constraint.getPriority());
+                        ruleConstraint.setDefault(constraint.isDefault());
+                        ((NodeImpl) node).setConstraint(outgoingConnection, ruleConstraint);
+                    } else if ("code".equals(constraint.getType())) {
+                        ReturnValueConstraintEvaluator returnValueConstraint = new ReturnValueConstraintEvaluator();
+                        returnValueConstraint.setDialect(constraint.getDialect());
+                        returnValueConstraint.setName(constraint.getName());
+                        returnValueConstraint.setPriority(constraint.getPriority());
+                        returnValueConstraint.setDefault(constraint.isDefault());
+                        ((NodeImpl) node).setConstraint(outgoingConnection, returnValueConstraint);
 
-                ReturnValueDescr returnValueDescr = new ReturnValueDescr();
-                returnValueDescr.setText(constraint.getConstraint());
-                returnValueDescr.setResource(processDescr.getResource());
+                        ReturnValueDescr returnValueDescr = new ReturnValueDescr();
+                        returnValueDescr.setText(constraint.getConstraint());
+                        returnValueDescr.setResource(processDescr.getResource());
 
-                ProcessDialect dialect = ProcessDialectRegistry.getDialect(constraint.getDialect());
-                dialect.getReturnValueEvaluatorBuilder().build(context, returnValueConstraint, returnValueDescr, (NodeImpl) node);
+                        ProcessDialect dialect = ProcessDialectRegistry.getDialect(constraint.getDialect());
+                        dialect.getReturnValueEvaluatorBuilder().build(context, returnValueConstraint, returnValueDescr, (NodeImpl) node);
+                    }
+                }
             }
         }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
@@ -18,8 +18,9 @@
  */
 package org.jbpm.process.builder;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 
 import org.drools.drl.ast.descr.ProcessDescr;
@@ -30,7 +31,6 @@ import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
 import org.jbpm.process.instance.impl.RuleConstraintEvaluator;
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.impl.ConnectionRef;
-import org.jbpm.workflow.core.impl.ConstraintImpl;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.Split;
 import org.kie.api.definition.process.Connection;
@@ -50,11 +50,11 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
             return;
         }
         // we need to clone the map, so we can update the original while iterating.
-        Map<ConnectionRef, Constraint> map = new HashMap<>(splitNode.getConstraints());
-        for (Iterator<Map.Entry<ConnectionRef, Constraint>> it = map.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<ConnectionRef, Constraint> entry = it.next();
+        Map<ConnectionRef, Collection<Constraint>> map = splitNode.getConstraints();
+        for (Iterator<Map.Entry<ConnectionRef, Collection<Constraint>>> it = map.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<ConnectionRef, Collection<Constraint>> entry = it.next();
             ConnectionRef connection = entry.getKey();
-            ConstraintImpl constraint = (ConstraintImpl) entry.getValue();
+            Collection<Constraint> constraints = entry.getValue();
             Connection outgoingConnection = null;
             for (Connection out : splitNode.getDefaultOutgoingConnections()) {
                 if (out.getToType().equals(connection.getToType())
@@ -65,35 +65,39 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
             if (outgoingConnection == null) {
                 throw new IllegalArgumentException("Could not find outgoing connection");
             }
-            if (constraint == null && splitNode.isDefault(outgoingConnection)) {
-                // do nothing since conditions are ignored for default sequence flow
-            } else if (constraint != null && "rule".equals(constraint.getType())) {
-                RuleConstraintEvaluator ruleConstraint = new RuleConstraintEvaluator();
-                ruleConstraint.setDialect(constraint.getDialect());
-                ruleConstraint.setName(constraint.getName());
-                ruleConstraint.setPriority(constraint.getPriority());
-                ruleConstraint.setDefault(constraint.isDefault());
-                ruleConstraint.setType(constraint.getType());
-                ruleConstraint.setConstraint(constraint.getConstraint());
-                splitNode.setConstraint(outgoingConnection, ruleConstraint);
-            } else if (constraint != null && "code".equals(constraint.getType())) {
-                ReturnValueConstraintEvaluator returnValueConstraint = new ReturnValueConstraintEvaluator();
-                returnValueConstraint.setDialect(constraint.getDialect());
-                returnValueConstraint.setName(constraint.getName());
-                returnValueConstraint.setPriority(constraint.getPriority());
-                returnValueConstraint.setDefault(constraint.isDefault());
-                returnValueConstraint.setType(constraint.getType());
-                returnValueConstraint.setConstraint(constraint.getConstraint());
-                splitNode.setConstraint(outgoingConnection, returnValueConstraint);
+            if (!splitNode.isDefault(outgoingConnection) && constraints != null)
+                for (Constraint constraint : new LinkedList<>(constraints)) {
+                    if (constraint != null) {
+                        if ("rule".equals(constraint.getType())) {
+                            RuleConstraintEvaluator ruleConstraint = new RuleConstraintEvaluator();
+                            ruleConstraint.setDialect(constraint.getDialect());
+                            ruleConstraint.setName(constraint.getName());
+                            ruleConstraint.setPriority(constraint.getPriority());
+                            ruleConstraint.setDefault(constraint.isDefault());
+                            ruleConstraint.setType(constraint.getType());
+                            ruleConstraint.setConstraint(constraint.getConstraint());
+                            splitNode.setConstraint(outgoingConnection, ruleConstraint);
+                        } else if ("code".equals(constraint.getType())) {
+                            ReturnValueConstraintEvaluator returnValueConstraint = new ReturnValueConstraintEvaluator();
+                            returnValueConstraint.setDialect(constraint.getDialect());
+                            returnValueConstraint.setName(constraint.getName());
+                            returnValueConstraint.setPriority(constraint.getPriority());
+                            returnValueConstraint.setDefault(constraint.isDefault());
+                            returnValueConstraint.setType(constraint.getType());
+                            returnValueConstraint.setConstraint(constraint.getConstraint());
+                            splitNode.setConstraint(outgoingConnection, returnValueConstraint);
 
-                ReturnValueDescr returnValueDescr = new ReturnValueDescr();
-                returnValueDescr.setText(constraint.getConstraint());
-                returnValueDescr.setResource(processDescr.getResource());
+                            ReturnValueDescr returnValueDescr = new ReturnValueDescr();
+                            returnValueDescr.setText(constraint.getConstraint());
+                            returnValueDescr.setResource(processDescr.getResource());
 
-                ProcessDialect dialect = ProcessDialectRegistry.getDialect(constraint.getDialect());
-                dialect.getReturnValueEvaluatorBuilder().build(context, returnValueConstraint, returnValueDescr, (NodeImpl) node);
-            }
+                            ProcessDialect dialect = ProcessDialectRegistry.getDialect(constraint.getDialect());
+                            dialect.getReturnValueEvaluatorBuilder().build(context, returnValueConstraint, returnValueDescr, (NodeImpl) node);
+                        }
+                    }
+                }
         }
+
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
@@ -270,7 +270,7 @@ public class RuleFlowProcessValidator implements ProcessValidator {
                 if (split.getType() == Split.TYPE_XOR || split.getType() == Split.TYPE_OR) {
                     for (final Iterator<Connection> it = split.getDefaultOutgoingConnections().iterator(); it.hasNext();) {
                         final Connection connection = it.next();
-                        Collection<Constraint> constraints = split.getConstraint(connection);
+                        Collection<Constraint> constraints = split.getConstraints(connection);
                         if ((constraints == null || constraints.stream().allMatch(c -> c == null || c.getConstraint() == null || c.getConstraint().isBlank())) && !split.isDefault(connection)) {
                             addErrorMessage(process,
                                     node,

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
@@ -20,6 +20,7 @@ package org.jbpm.ruleflow.core.validation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -43,6 +44,7 @@ import org.jbpm.process.core.validation.ProcessValidator;
 import org.jbpm.process.core.validation.impl.ProcessValidationErrorImpl;
 import org.jbpm.ruleflow.core.Metadata;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.WorkflowProcess;
@@ -268,10 +270,8 @@ public class RuleFlowProcessValidator implements ProcessValidator {
                 if (split.getType() == Split.TYPE_XOR || split.getType() == Split.TYPE_OR) {
                     for (final Iterator<Connection> it = split.getDefaultOutgoingConnections().iterator(); it.hasNext();) {
                         final Connection connection = it.next();
-                        if (split.getConstraint(connection) == null && !split.isDefault(connection)
-                                || (!split.isDefault(connection)
-                                        && (split.getConstraint(connection).getConstraint() == null
-                                                || split.getConstraint(connection).getConstraint().trim().length() == 0))) {
+                        Collection<Constraint> constraints = split.getConstraint(connection);
+                        if ((constraints == null || constraints.stream().allMatch(c -> c == null || c.getConstraint() == null || c.getConstraint().isBlank())) && !split.isDefault(connection)) {
                             addErrorMessage(process,
                                     node,
                                     errors,

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.jbpm.process.core.Context;
 import org.jbpm.process.core.ContextResolver;
 import org.jbpm.process.core.context.variable.Mappable;
+import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.Node;
@@ -435,7 +436,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
                     "A " + this.getName() + " node only accepts constraints linked to a connection");
         }
         Collection<Constraint> values = this.constraints.computeIfAbsent(connectionRef, r -> new ArrayList<>());
-        values.removeIf(v -> Objects.equals(v.getConstraint(), constraint.getConstraint()));
+        values.removeIf(v -> !ReturnValueConstraintEvaluator.class.isInstance(v) && Objects.equals(v.getConstraint(), constraint.getConstraint()));
         values.add(constraint);
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
@@ -401,14 +401,18 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
         this.metaData = metaData;
     }
 
-    public Collection<Constraint> getConstraint(final Connection connection) {
+    public Collection<Constraint> getConstraints(final Connection connection) {
         if (connection == null) {
             throw new IllegalArgumentException("connection is null");
         }
 
         ConnectionRef ref = new ConnectionRef((String) connection.getMetaData().get("UniqueId"), connection.getTo().getId(), connection.getToType());
         return this.constraints.get(ref);
+    }
 
+    public Constraint getConstraint(final Connection connection) {
+        Collection<Constraint> constraints = getConstraints(connection);
+        return constraints != null ? constraints.iterator().next() : null;
     }
 
     public Constraint internalGetConstraint(final ConnectionRef ref) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
@@ -102,7 +102,7 @@ public class Split extends NodeImpl implements Constrainable {
     }
 
     @Override
-    public Collection<Constraint> getConstraint(final Connection connection) {
+    public Collection<Constraint> getConstraints(final Connection connection) {
         if (connection == null) {
             throw new IllegalArgumentException("connection is null");
         }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
@@ -18,8 +18,7 @@
  */
 package org.jbpm.workflow.core.node;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Collection;
 
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.Node;
@@ -86,23 +85,24 @@ public class Split extends NodeImpl implements Constrainable {
 
         if (this.type == TYPE_OR || this.type == TYPE_XOR) {
             ConnectionRef ref = new ConnectionRef((String) connection.getMetaData().get("UniqueId"), connection.getTo().getId(), connection.getToType());
-            Constraint constraint = this.constraints.get(ref);
+            Collection<Constraint> constraints = this.constraints.get(ref);
+            if (constraints != null) {
+                for (Constraint constraint : constraints) {
+                    if (constraint != null) {
+                        return constraint.isDefault();
+                    }
+                }
+            }
             String defaultConnection = (String) getMetaData().get("Default");
             String connectionId = (String) connection.getMetaData().get("UniqueId");
-            if (constraint != null) {
-                return constraint.isDefault();
-            } else if (constraint == null && connectionId.equals(defaultConnection)) {
-                return true;
-            } else {
-                return false;
-            }
+            return connectionId.equals(defaultConnection);
         }
         throw new UnsupportedOperationException("Constraints are " +
                 "only supported with XOR or OR split types, not with: " + getType());
     }
 
     @Override
-    public Constraint getConstraint(final Connection connection) {
+    public Collection<Constraint> getConstraint(final Connection connection) {
         if (connection == null) {
             throw new IllegalArgumentException("connection is null");
         }
@@ -113,11 +113,6 @@ public class Split extends NodeImpl implements Constrainable {
         }
         throw new UnsupportedOperationException("Constraints are " +
                 "only supported with XOR or OR split types, not with: " + getType());
-    }
-
-    @Override
-    public Constraint internalGetConstraint(final ConnectionRef ref) {
-        return this.constraints.get(ref);
     }
 
     @Override
@@ -137,20 +132,6 @@ public class Split extends NodeImpl implements Constrainable {
             throw new UnsupportedOperationException("Constraints are " +
                     "only supported with XOR or OR split types, not with type:" + getType());
         }
-    }
-
-    @Override
-    public void addConstraint(ConnectionRef connectionRef, Constraint constraint) {
-        if (connectionRef == null) {
-            throw new IllegalArgumentException(
-                    "A split node only accepts constraints linked to a connection");
-        }
-        this.constraints.put(connectionRef, constraint);
-    }
-
-    @Override
-    public Map<ConnectionRef, Constraint> getConstraints() {
-        return Collections.unmodifiableMap(this.constraints);
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateNode.java
@@ -18,60 +18,7 @@
  */
 package org.jbpm.workflow.core.node;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.jbpm.workflow.core.Constraint;
-import org.jbpm.workflow.core.impl.ConnectionRef;
-import org.kie.api.definition.process.Connection;
-
 public class StateNode extends CompositeContextNode implements Constrainable {
 
     private static final long serialVersionUID = 510l;
-
-    private Map<ConnectionRef, Constraint> constraints = new HashMap<>();
-
-    public void setConstraints(Map<ConnectionRef, Constraint> constraints) {
-        this.constraints = constraints;
-    }
-
-    @Override
-    public void setConstraint(final Connection connection, final Constraint constraint) {
-        if (connection == null) {
-            throw new IllegalArgumentException("connection is null");
-        }
-        if (!getDefaultOutgoingConnections().contains(connection)) {
-            throw new IllegalArgumentException("connection is unknown:" + connection);
-        }
-        addConstraint(new ConnectionRef((String) connection.getMetaData().get("UniqueId"),
-                connection.getTo().getId(), connection.getToType()), constraint);
-    }
-
-    @Override
-    public void addConstraint(ConnectionRef connectionRef, Constraint constraint) {
-        if (connectionRef == null) {
-            throw new IllegalArgumentException(
-                    "A state node only accepts constraints linked to a connection");
-        }
-        constraints.put(connectionRef, constraint);
-    }
-
-    public Constraint getConstraint(ConnectionRef connectionRef) {
-        return constraints.get(connectionRef);
-    }
-
-    @Override
-    public Map<ConnectionRef, Constraint> getConstraints() {
-        return constraints;
-    }
-
-    @Override
-    public Constraint getConstraint(final Connection connection) {
-        if (connection == null) {
-            throw new IllegalArgumentException("connection is null");
-        }
-        ConnectionRef ref = new ConnectionRef((String) connection.getMetaData().get("UniqueId"), connection.getTo().getId(), connection.getToType());
-        return this.constraints.get(ref);
-    }
-
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -324,7 +324,7 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
                     Connection selectedConnection = null;
                     ConstraintEvaluator selectedConstraint = null;
                     for (final Connection connection : outgoingCopy) {
-                        Collection<Constraint> constraints = ((NodeImpl) node).getConstraint(connection);
+                        Collection<Constraint> constraints = ((NodeImpl) node).getConstraints(connection);
                         if (constraints != null) {
                             for (Constraint constraint : constraints) {
                                 if (constraint instanceof ConstraintEvaluator && constraint.getPriority() < priority
@@ -357,7 +357,7 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
                 }
                 if (!found) {
                     for (final Connection connection : connections) {
-                        Collection<Constraint> constraints = ((NodeImpl) node).getConstraint(connection);
+                        Collection<Constraint> constraints = ((NodeImpl) node).getConstraints(connection);
                         if (constraints != null) {
                             for (Constraint constraint : constraints) {
                                 if (constraint.isDefault()) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
@@ -85,7 +85,7 @@ public class SplitInstance extends NodeInstanceImpl {
                 Connection selected = null;
                 for (final Iterator<Connection> iterator = outgoing.iterator(); iterator.hasNext();) {
                     final Connection connection = iterator.next();
-                    Collection<Constraint> constraints = split.getConstraint(connection);
+                    Collection<Constraint> constraints = split.getConstraints(connection);
                     if (constraints != null) {
                         for (Constraint constraint : constraints) {
                             if (constraint instanceof ConstraintEvaluator && constraint.getPriority() < priority && !constraint.isDefault()) {
@@ -139,7 +139,7 @@ public class SplitInstance extends NodeInstanceImpl {
                     ConstraintEvaluator selectedConstraint = null;
                     for (final Iterator<Connection> iterator = outgoingCopy.iterator(); iterator.hasNext();) {
                         final Connection connection = iterator.next();
-                        Collection<Constraint> constraints = split.getConstraint(connection);
+                        Collection<Constraint> constraints = split.getConstraints(connection);
                         if (constraints != null) {
                             for (Constraint constraint : constraints) {
                                 if (constraint instanceof ConstraintEvaluator && constraint.getPriority() < priority
@@ -174,7 +174,7 @@ public class SplitInstance extends NodeInstanceImpl {
                     final Iterator<Connection> iterator = outgoing.iterator();
                     while (!found && iterator.hasNext()) {
                         final Connection connection = iterator.next();
-                        Collection<Constraint> constraints = split.getConstraint(connection);
+                        Collection<Constraint> constraints = split.getConstraints(connection);
                         if (constraints != null) {
                             for (Constraint constraint : constraints) {
                                 if (constraint != null && constraint.isDefault()) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
@@ -18,6 +18,8 @@
  */
 package org.jbpm.workflow.instance.node;
 
+import java.util.Collection;
+
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.rule.consequence.InternalMatch;
 import org.jbpm.workflow.core.Constraint;
@@ -50,17 +52,22 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
         Connection selected = null;
         int priority = Integer.MAX_VALUE;
         for (Connection connection : stateNode.getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
-            Constraint constraint = stateNode.getConstraint(connection);
-            if (constraint != null && constraint.getPriority() < priority) {
-                String rule = "RuleFlowStateNode-" + getProcessInstance().getProcessId() + "-" +
-                        getStateNode().getUniqueId() + "-" +
-                        connection.getTo().getId() + "-" +
-                        connection.getToType();
-                boolean isActive = ((InternalAgenda) getProcessInstance().getKnowledgeRuntime().getAgenda())
-                        .isRuleActiveInRuleFlowGroup("DROOLS_SYSTEM", rule, getProcessInstance().getStringId());
-                if (isActive) {
-                    selected = connection;
-                    priority = constraint.getPriority();
+            Collection<Constraint> constraints = stateNode.getConstraint(connection);
+
+            if (constraints != null) {
+                for (Constraint constraint : constraints) {
+                    if (constraint.getPriority() < priority) {
+                        String rule = "RuleFlowStateNode-" + getProcessInstance().getProcessId() + "-" +
+                                getStateNode().getUniqueId() + "-" +
+                                connection.getTo().getId() + "-" +
+                                connection.getToType();
+                        boolean isActive = ((InternalAgenda) getProcessInstance().getKnowledgeRuntime().getAgenda())
+                                .isRuleActiveInRuleFlowGroup("DROOLS_SYSTEM", rule, getProcessInstance().getStringId());
+                        if (isActive) {
+                            selected = connection;
+                            priority = constraint.getPriority();
+                        }
+                    }
                 }
             }
         }
@@ -71,6 +78,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
             addTriggerListener();
             addActivationListener();
         }
+
     }
 
     @Override
@@ -84,14 +92,19 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
             if (event instanceof String) {
                 for (Connection connection : getStateNode().getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
                     boolean selected = false;
-                    Constraint constraint = getStateNode().getConstraint(connection);
-                    if (constraint == null) {
+                    Collection<Constraint> constraints = getStateNode().getConstraint(connection);
+                    if (constraints == null) {
                         if (event.equals(connection.getTo().getName())) {
                             selected = true;
                         }
-                    } else if (event.equals(constraint.getName())) {
-                        selected = true;
-                    }
+                    } else
+                        for (Constraint constraint : constraints) {
+
+                            if (event.equals(constraint.getName())) {
+                                selected = true;
+                                break;
+                            }
+                        }
                     if (selected) {
                         triggerEvent(ExtendedNodeImpl.EVENT_NODE_EXIT);
                         removeEventListeners();
@@ -146,14 +159,15 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
     public void activationCreated(MatchCreatedEvent event) {
         Connection selected = null;
         for (Connection connection : getNode().getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
-            Constraint constraint = getStateNode().getConstraint(connection);
-            if (constraint != null) {
+            Collection<Constraint> constraints = getStateNode().getConstraint(connection);
+            if (constraints != null) {
                 String constraintName = getActivationEventType() + "-"
                         + connection.getTo().getId() + "-" + connection.getToType();
                 if (constraintName.equals(event.getMatch().getRule().getName())
                         && checkProcessInstance((InternalMatch) event.getMatch())) {
                     selected = connection;
                 }
+
             }
         }
         if (selected != null) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
@@ -52,7 +52,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
         Connection selected = null;
         int priority = Integer.MAX_VALUE;
         for (Connection connection : stateNode.getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
-            Collection<Constraint> constraints = stateNode.getConstraint(connection);
+            Collection<Constraint> constraints = stateNode.getConstraints(connection);
 
             if (constraints != null) {
                 for (Constraint constraint : constraints) {
@@ -92,7 +92,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
             if (event instanceof String) {
                 for (Connection connection : getStateNode().getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
                     boolean selected = false;
-                    Collection<Constraint> constraints = getStateNode().getConstraint(connection);
+                    Collection<Constraint> constraints = getStateNode().getConstraints(connection);
                     if (constraints == null) {
                         if (event.equals(connection.getTo().getName())) {
                             selected = true;
@@ -159,7 +159,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
     public void activationCreated(MatchCreatedEvent event) {
         Connection selected = null;
         for (Connection connection : getNode().getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
-            Collection<Constraint> constraints = getStateNode().getConstraint(connection);
+            Collection<Constraint> constraints = getStateNode().getConstraints(connection);
             if (constraints != null) {
                 String constraintName = getActivationEventType() + "-"
                         + connection.getTo().getId() + "-" + connection.getToType();

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -532,11 +532,11 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
             assertThat(cNode.getConstraints()).isNull();
             return;
         }
-        Map<ConnectionRef, Constraint> expected = eNode.getConstraints();
-        Map<ConnectionRef, Constraint> current = cNode.getConstraints();
+        Map<ConnectionRef, Collection<Constraint>> expected = eNode.getConstraints();
+        Map<ConnectionRef, Collection<Constraint>> current = cNode.getConstraints();
         assertThat(current).hasSameSizeAs(expected);
         expected.forEach((conn, constraint) -> {
-            Optional<Map.Entry<ConnectionRef, Constraint>> currentEntry = current.entrySet()
+            Optional<Map.Entry<ConnectionRef, Collection<Constraint>>> currentEntry = current.entrySet()
                     .stream()
                     .filter(e -> e.getKey().getConnectionId() == null && conn.getConnectionId() == null ||
                             e.getKey().getConnectionId().equals(conn.getConnectionId()))
@@ -545,13 +545,15 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
             ConnectionRef currentConn = currentEntry.get().getKey();
             assertThat(currentConn.getNodeId()).isEqualTo(conn.getNodeId());
             assertThat(currentConn.getToType()).isEqualTo(conn.getToType());
-            Constraint currentConstraint = currentEntry.get().getValue();
+            Collection<Constraint> constraints = currentEntry.get().getValue();
             if (constraint == null) {
-                assertThat(currentConstraint).isNull();
+                assertThat(constraints).isNull();
             } else {
+                Constraint currentConstraint = constraints.iterator().next();
+                Constraint expectedConstraint = constraint.iterator().next();
                 assertThat(currentConstraint).isNotNull();
-                assertThat(currentConstraint.getPriority()).isEqualTo(constraint.getPriority());
-                assertThat(currentConstraint.getDialect()).isEqualTo(constraint.getDialect());
+                assertThat(currentConstraint.getPriority()).isEqualTo(expectedConstraint.getPriority());
+                assertThat(currentConstraint.getDialect()).isEqualTo(expectedConstraint.getDialect());
                 assertThat(currentConstraint.getName()).isEqualTo(conn.getConnectionId());
                 assertThat(currentConstraint.getType()).isEqualTo(CONNECTION_DEFAULT_TYPE);
             }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.serverless.workflow;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.jbpm.ruleflow.core.Metadata;
@@ -577,12 +578,7 @@ public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowPar
         assertThat(split.getType()).isEqualTo(2);
         assertThat(split.getConstraints()).hasSize(2);
 
-        boolean haveDefaultConstraint = false;
-        for (Constraint constraint : split.getConstraints().values()) {
-            haveDefaultConstraint = haveDefaultConstraint || constraint.isDefault();
-        }
-
-        assertThat(haveDefaultConstraint).isTrue();
+        assertHaveDefaultConstraint(split);
     }
 
     @ParameterizedTest
@@ -603,12 +599,11 @@ public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowPar
         assertThat(split.getType()).isEqualTo(2);
         assertThat(split.getConstraints()).hasSize(2);
 
-        boolean haveDefaultConstraint = false;
-        for (Constraint constraint : split.getConstraints().values()) {
-            haveDefaultConstraint = haveDefaultConstraint || constraint.isDefault();
-        }
+        assertHaveDefaultConstraint(split);
+    }
 
-        assertThat(haveDefaultConstraint).isTrue();
+    private void assertHaveDefaultConstraint(Split split) {
+        assertThat(split.getConstraints().values().stream().flatMap(Collection::stream).anyMatch(Constraint::isDefault)).isTrue();
     }
 
     @ParameterizedTest

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/WorkflowTestUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/WorkflowTestUtils.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -150,6 +151,7 @@ public class WorkflowTestUtils {
 
     public static void assertConstraintIsDefault(Split splitNode, String constraintName) {
         Constraint constraint = splitNode.getConstraints().values().stream()
+                .flatMap(Collection::stream)
                 .filter(c -> constraintName.equals(c.getName()))
                 .findFirst().orElse(null);
         assertThat(constraint)

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/test/resources/switch.yaml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/test/resources/switch.yaml
@@ -1,0 +1,32 @@
+version: 1.0.0
+specVersion: "0.8"
+id: Switch test
+name: Switch test
+start: switch test
+states:
+  - name: switch test
+    type: switch
+    dataConditions:
+      - name: Branch1-Name
+        condition: .condition1
+        transition: branch1
+      - name: Branch2-Name
+        condition: .condition2
+        transition: branch1
+
+    defaultCondition:
+      transition: default
+
+  - name: branch1
+    type: inject
+    data:
+      output: branch1
+    end: true
+
+
+  - name: default
+    type: inject
+    data:
+      output: default
+    end: true
+ 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/3456
The engine was not ready to support multiple constraints over the same connection. That makes sense for BPMN, but it is not necesarily true for SWF, as shown by the example in the issue.
Therefore, it has been changed to support both  (BPMN constraint will be size one)