### PR TITLE
[Fix #3483] Adding state duration summary

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/utils/KogitoTags.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/utils/KogitoTags.java
@@ -27,4 +27,6 @@ public class KogitoTags {
     public static final String INPUT_TAG = "input";
     public static final String OUTPUT_TAG = "output";
 
+    public static final String METRIC_NAME_METADATA = "MetricName";
+
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -189,7 +189,7 @@ public abstract class StateHandler<S extends State> {
 
     protected void handleState(RuleFlowNodeContainerFactory<?, ?> factory) {
         MakeNodeResult result = makeNode(factory);
-        node = result.getIncomingNode().metaData(SWFConstants.STATE_NAME, state.getName());
+        node = result.getIncomingNode().metaData(SWFConstants.STATE_NAME, state.getName()).metaData(KogitoTags.METRIC_NAME_METADATA, state.getName());
         outgoingNode = result.getOutgoingNode().metaData(SWFConstants.STATE_NAME, state.getName());
         if (state.getCompensatedBy() != null) {
             handleCompensation(factory);
@@ -208,7 +208,7 @@ public abstract class StateHandler<S extends State> {
             if (output != null) {
                 ActionNodeFactory<?> actionNode = handleStateFilter(factory, output);
                 factory.connection(outgoingNode.getNode().getId(), actionNode.getNode().getId());
-                outgoingNode = actionNode.metaData(SWFConstants.STATE_NAME, state.getName());
+                outgoingNode = actionNode.metaData(SWFConstants.STATE_NAME, state.getName()).metaData(KogitoTags.METRIC_NAME_METADATA, state.getName());
             }
         }
         connectStart(factory);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/3483
Add "kogito_node_instance_duration_milliseconds" distribution summary. 
Different to the other two summaries, times are collected in milliseconds rather than seconds