### PR TITLE
Process test migration from v7 legacy runtime to code generation (Issue #1131)

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.drools.compiler.rule.builder.PackageBuildContext;
+import org.jbpm.bpmn2.flow.*;
 import org.jbpm.bpmn2.handler.ReceiveTaskHandler;
 import org.jbpm.bpmn2.handler.SendTaskHandler;
 import org.jbpm.bpmn2.handler.ServiceTaskHandler;
@@ -36,6 +37,8 @@ import org.jbpm.bpmn2.objects.Person;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.bpmn2.subprocess.SubProcessWithEntryExitScriptsModel;
 import org.jbpm.bpmn2.subprocess.SubProcessWithEntryExitScriptsProcess;
+import org.jbpm.bpmn2.task.SendTaskModel;
+import org.jbpm.bpmn2.task.SendTaskProcess;
 import org.jbpm.bpmn2.test.RequirePersistence;
 import org.jbpm.process.builder.ActionBuilder;
 import org.jbpm.process.builder.AssignmentBuilder;
@@ -99,30 +102,42 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMinimalProcess() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/flow/BPMN2-MinimalProcess.bpmn2");
-        KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
-        assertProcessInstanceCompleted(processInstance);
+        Application app = ProcessTestHelper.newApplication();
+        org.kie.kogito.process.Process<MinimalModel> minimalProcess = MinimalProcess.newProcess(app);
+        MinimalModel model = minimalProcess.createModel();
+        org.kie.kogito.process.ProcessInstance<MinimalModel> instance = minimalProcess.createInstance(model);
+        instance.start();
+        assertThat(instance.status()).isEqualTo(org.kie.kogito.process.ProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testMinimalProcessImplicit() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/flow/BPMN2-MinimalProcessImplicit.bpmn2");
-        KogitoProcessInstance processInstance = kruntime.startProcess("MinimalImplicit");
-        assertProcessInstanceCompleted(processInstance);
+        Application app = ProcessTestHelper.newApplication();
+        org.kie.kogito.process.Process<MinimalImplicitModel> minimalImplicitProcess = MinimalImplicitProcess.newProcess(app);
+        MinimalImplicitModel model = minimalImplicitProcess.createModel();
+        ProcessInstance<MinimalImplicitModel> instance = minimalImplicitProcess.createInstance(model);
+        instance.start();
+        assertThat(instance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testMinimalProcessWithGraphical() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/flow/BPMN2-MinimalProcessWithGraphical.bpmn2");
-        KogitoProcessInstance processInstance = kruntime.startProcess("MinimalWithGraphical");
-        assertProcessInstanceCompleted(processInstance);
+            Application app = ProcessTestHelper.newApplication();
+            org.kie.kogito.process.Process<MinimalWithGraphicalModel> minimalwithgraphicalprocess = MinimalWithGraphicalProcess.newProcess(app);
+            MinimalWithGraphicalModel model = minimalwithgraphicalprocess.createModel();
+            ProcessInstance<MinimalWithGraphicalModel> instance = minimalwithgraphicalprocess.createInstance(model);
+            instance.start();
+            assertThat(instance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testMinimalProcessWithDIGraphical() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/flow/BPMN2-MinimalProcessWithDIGraphical.bpmn2");
-        KogitoProcessInstance processInstance = kruntime.startProcess("MinimalWithDIGraphical");
-        assertProcessInstanceCompleted(processInstance);
+        Application app = ProcessTestHelper.newApplication();
+        org.kie.kogito.process.Process<MinimalWithDIGraphicalModel> minimalwithdigraphicalprocess = MinimalWithDIGraphicalProcess.newProcess(app);
+        MinimalWithDIGraphicalModel model = minimalwithdigraphicalprocess.createModel();
+        ProcessInstance<MinimalWithDIGraphicalModel> instance = minimalwithdigraphicalprocess.createInstance(model);
+        instance.start();
+        assertThat(instance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
 
     @Test
@@ -828,15 +843,14 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSendTask() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/task/BPMN2-SendTask.bpmn2");
-
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Send Task",
-                new SendTaskHandler());
-        Map<String, Object> params = new HashMap<>();
-        params.put("s", "john");
-        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
-                .startProcess("SendTask", params);
-        assertProcessInstanceFinished(processInstance, kruntime);
+        Application app = ProcessTestHelper.newApplication();
+        ProcessTestHelper.registerHandler(app, "Send Task", new SendTaskHandler());
+        org.kie.kogito.process.Process<SendTaskModel> processDefinition = SendTaskProcess.newProcess(app);
+        SendTaskModel model = processDefinition.createModel();
+        model.setS("john");
+        org.kie.kogito.process.ProcessInstance<SendTaskModel> instance = processDefinition.createInstance(model);
+        instance.start();
+        assertThat(instance.status()).isEqualTo(org.kie.kogito.process.ProcessInstance.STATE_COMPLETED);
     }
 
     @Test
@@ -936,6 +950,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertThat(list).hasSize(1);
     }
 
+    // The model does not have set myVar
     @Test
     public void testScriptTaskWithVariableByName() throws Exception {
         Map<String, Object> params = new HashMap<>();


### PR DESCRIPTION
Migrated some BPMN processes which are being compiled using legacy v7 to code generation approach.

The tests can be identified by referring to Activitytest.java:
<https://github.com/apache/incubator-kie-kogito-runtimes/blob/main/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java>

**Issue**: <https://github.com/apache/incubator-kie-issues/issues/1131>