### PR TITLE
Upgrading SpringBoot 3.2.5 to address CVE-2024-22262 found on spring-web.

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -37,7 +37,7 @@
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>3.8.4</version.io.quarkus>
     <version.io.quarkus.quarkus-test>${version.io.quarkus}</version.io.quarkus.quarkus-test>
-    <version.org.springframework.boot>3.2.4</version.org.springframework.boot>
+    <version.org.springframework.boot>3.2.5</version.org.springframework.boot>
     <version.org.apache.kafka>3.6.1</version.org.apache.kafka>
 
     <!-- dependencies versions -->


### PR DESCRIPTION
Related https://github.com/apache/incubator-kie-issues/issues/1202