### PR TITLE
[NO-ISSUE] Use apache-release profile when doing a release build

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -163,16 +163,21 @@ pipeline {
                                     sh ('rm $WORKSPACE/signkey.gpg')
 
                                     mvnCmd.withProperty('gpg.passphrase', SIGNING_KEY_PASSWORD)
+                                        .withProfiles(['apache-release'])
+
+                                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                                        mvnCmd.withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                            .run("clean $installOrDeploy")
+                                    }
                                 }
                             }
-                            mvnCmd.withProfiles(['apache-release'])
+                        } else {
+                            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                                mvnCmd.withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                    .run("clean $installOrDeploy")
+                            }
                         }
 
-                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
-                            mvnCmd
-                                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
-                                .run("clean $installOrDeploy")
-                        }
                     }
                 }
             }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -152,6 +152,17 @@ pipeline {
                         if (params.SKIP_TESTS) {
                             mvnCmd.skipTests() // Conflict somehow with Python testing. If `skipTests={anyvalue}` is set, then exec plugin is not executed ...
                         }
+                        if (isRelease()) {
+                            withCredentials([file(credentialsId: 'asf-release-gpg-signing-key', variable: 'SIGNING_KEY')]) {
+                                // copy the key to singkey.gpg file in *plain text* so we can import it
+                                sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
+                                // import the key into the gpg keyring
+                                sh ('gpg --allow-secret-key-import --import signkey.gpg')
+                                sh ('rm $WORKSPACE/signkey.gpg')
+                            }
+                            mvnCmd.withProfiles(['apache-release'])
+                        }
+
                         configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
                             mvnCmd
                                 .withSettingsXmlFile(MAVEN_SETTINGS_FILE)

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -154,11 +154,14 @@ pipeline {
                         }
                         if (isRelease()) {
                             withCredentials([file(credentialsId: 'asf-release-gpg-signing-key', variable: 'SIGNING_KEY')]) {
-                                // copy the key to singkey.gpg file in *plain text* so we can import it
-                                sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
-                                // import the key into the gpg keyring
-                                sh ('gpg --allow-secret-key-import --import signkey.gpg')
-                                sh ('rm $WORKSPACE/signkey.gpg')
+                                withCredentials([file(credentialsId: 'asf-release-gpg-signing-key-password', variable: 'SIGNING_KEY_PASSWORD')]) {
+                                    // copy the key to singkey.gpg file in *plain text* so we can import it
+                                    sh ('cat $SIGNING_KEY > $WORKSPACE/signkey.gpg')
+                                    // Please do not remove list keys command. When gpg is run for the first time, it may initialize some internals.
+                                    sh ('gpg --list-keys')
+                                    sh ("gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import signkey.gpg")
+                                    sh ('rm $WORKSPACE/signkey.gpg')
+                                }
                             }
                             mvnCmd.withProfiles(['apache-release'])
                         }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -161,6 +161,8 @@ pipeline {
                                     sh ('gpg --list-keys')
                                     sh ("gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import signkey.gpg")
                                     sh ('rm $WORKSPACE/signkey.gpg')
+
+                                    mvnCmd.withProperty('gpg.passphrase', SIGNING_KEY_PASSWORD)
                                 }
                             }
                             mvnCmd.withProfiles(['apache-release'])

--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -661,6 +661,16 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${version.maven-javadoc-plugin}</version>
+          <configuration>
+            <quiet>true</quiet>
+            <doclint>none</doclint>
+            <legacyMode>true</legacyMode>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <project.build.outputTimestamp>2024-01-16T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
+    <version.maven-javadoc-plugin>3.6.2</version.maven-javadoc-plugin>
   </properties>
 
   <build>


### PR DESCRIPTION
- Adds gpg setup and apache-release Maven profile to the release build.
- Fixes javadoc build on JDK 17. 