### PR TITLE
[Fix_#3546] NodeInstanceFactoryProvided not included in native build

### DIFF
--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -42,6 +42,8 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
+import org.jbpm.ruleflow.core.factory.provider.NodeFactoryProvider;
+import org.jbpm.workflow.instance.impl.NodeInstanceFactoryProvider;
 import org.kie.efesto.quarkus.deployment.EfestoGeneratedClassBuildItem;
 import org.kie.kogito.KogitoGAV;
 import org.kie.kogito.codegen.api.Generator;
@@ -63,9 +65,11 @@ import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
@@ -155,6 +159,14 @@ public class KogitoAssetsProcessor {
             generatedFiles.add(new GeneratedFile(GeneratedFileType.SOURCE, HOT_RELOAD_SUPPORT_PATH + ".java", getHotReloadSupportSource()));
         }
         return new KogitoGeneratedSourcesBuildItem(generatedFiles);
+    }
+
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    public void addNativeLoaders(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(NodeInstanceFactoryProvider.class.getCanonicalName()));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(NodeFactoryProvider.class.getCanonicalName()));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath("org.jbpm.flow.serialization.NodeInstanceWriter"));
+        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath("org.jbpm.flow.serialization.NodeInstanceReader"));
     }
 
     @BuildStep

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -42,8 +42,6 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.logging.Logger;
-import org.jbpm.ruleflow.core.factory.provider.NodeFactoryProvider;
-import org.jbpm.workflow.instance.impl.NodeInstanceFactoryProvider;
 import org.kie.efesto.quarkus.deployment.EfestoGeneratedClassBuildItem;
 import org.kie.kogito.KogitoGAV;
 import org.kie.kogito.codegen.api.Generator;
@@ -65,11 +63,9 @@ import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
-import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.maven.dependency.Dependency;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
@@ -159,14 +155,6 @@ public class KogitoAssetsProcessor {
             generatedFiles.add(new GeneratedFile(GeneratedFileType.SOURCE, HOT_RELOAD_SUPPORT_PATH + ".java", getHotReloadSupportSource()));
         }
         return new KogitoGeneratedSourcesBuildItem(generatedFiles);
-    }
-
-    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
-    public void addNativeLoaders(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
-        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(NodeInstanceFactoryProvider.class.getCanonicalName()));
-        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(NodeFactoryProvider.class.getCanonicalName()));
-        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath("org.jbpm.flow.serialization.NodeInstanceWriter"));
-        serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath("org.jbpm.flow.serialization.NodeInstanceReader"));
     }
 
     @BuildStep

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.native.auto-service-loader-registration=true


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-runtimes/issues/3546. This is an issue in native build consequence of the refactor done by https://github.com/apache/incubator-kie-kogito-runtimes/pull/3482
I think including the service loader classes should be enough for native compiler to realize it should include all node classes, but @domhanak please let us know if the issue is fixed by this change