### PR TITLE
Fix Springboot IT test reproducible failing when code is modified for build time only modules

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/src/main/java/org/kie/kogito/serverless/workflow/operationid/SpecWorkflowOperationIdFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/src/main/java/org/kie/kogito/serverless/workflow/operationid/SpecWorkflowOperationIdFactory.java
@@ -24,6 +24,8 @@ import java.util.Set;
 
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.utils.OpenAPIFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.functions.FunctionDefinition;
@@ -31,8 +33,11 @@ import io.serverlessworkflow.api.functions.FunctionDefinition;
 public class SpecWorkflowOperationIdFactory extends AbstractWorkflowOperationIdFactory {
     public static final String SPEC_PROP_VALUE = "SPEC_TITLE";
 
+    private static final Logger logger = LoggerFactory.getLogger(SpecWorkflowOperationIdFactory.class);
+
     @Override
     public String getFileName(Workflow workflow, FunctionDefinition function, Optional<ParserContext> context, URI uri, String operation, String service) {
+        logger.debug("Testing reproducible");
         return OpenAPIFactory.getOpenAPI(uri, workflow, function, context).getInfo()
                 .getTitle();
     }

--- a/springboot/integration-tests/pom.xml
+++ b/springboot/integration-tests/pom.xml
@@ -76,6 +76,10 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-serverless-workflow-openapi-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-maven-plugin</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
If common-openapi jar is modified, reproducilbe will always fail no matter the nature of the change.
The PR makes a dummy modification on common-openapi, which makes reprodubile to fail on CI, and change the pom for  springboot integration test in order to avoid that failure.