### PR TITLE
Increase timeout in flaky test

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -993,7 +993,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         model.setX("oldValue");
         ProcessInstance<CallActivityWithBoundaryEventModel> processInstance = process.createInstance(model);
         processInstance.start();
-        listener.waitTillCompleted();
+        listener.waitTillCompleted(15000);
         assertThat(processInstance).extracting(ProcessInstance::status).isEqualTo(ProcessInstance.STATE_COMPLETED);
         Collection<String> processNodes = process.findNodes(Objects::nonNull).stream().map(Node::getName).collect(Collectors.toSet());
         Collection<String> subProcessNodes = callActivitySubProcessWithBoundaryEventProcess.findNodes(Objects::nonNull).stream().map(Node::getName).collect(Collectors.toSet());


### PR DESCRIPTION
In local env this takes more that 2s. It is possible that in CI, it takes more than 10 (several PRs are failing in this test consistently)
For some reason I cannot include @Abhitocode in the list of reviewers
