### PR TITLE
[incubator-kie-issues-1131] test migration from V7 to code generation-7

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +45,34 @@ import org.jbpm.bpmn2.activity.UserTaskWithSimulationMetaDataModel;
 import org.jbpm.bpmn2.activity.UserTaskWithSimulationMetaDataProcess;
 import org.jbpm.bpmn2.adhoc.SubProcessInAdHocProcessModel;
 import org.jbpm.bpmn2.adhoc.SubProcessInAdHocProcessProcess;
-import org.jbpm.bpmn2.flow.*;
+import org.jbpm.bpmn2.flow.CompositeWithDIGraphicalModel;
+import org.jbpm.bpmn2.flow.CompositeWithDIGraphicalProcess;
+import org.jbpm.bpmn2.flow.MinimalImplicitModel;
+import org.jbpm.bpmn2.flow.MinimalImplicitProcess;
+import org.jbpm.bpmn2.flow.MinimalModel;
+import org.jbpm.bpmn2.flow.MinimalProcess;
+import org.jbpm.bpmn2.flow.MinimalWithDIGraphicalModel;
+import org.jbpm.bpmn2.flow.MinimalWithDIGraphicalProcess;
+import org.jbpm.bpmn2.flow.MinimalWithGraphicalModel;
+import org.jbpm.bpmn2.flow.MinimalWithGraphicalProcess;
+import org.jbpm.bpmn2.flow.ProcessCustomDescriptionMetaDataModel;
+import org.jbpm.bpmn2.flow.ProcessCustomDescriptionMetaDataProcess;
+import org.jbpm.bpmn2.flow.ProcessVariableCustomDescriptionMetaDataModel;
+import org.jbpm.bpmn2.flow.ProcessVariableCustomDescriptionMetaDataProcess;
+import org.jbpm.bpmn2.flow.ProcessWithVariableNameModel;
+import org.jbpm.bpmn2.flow.ProcessWithVariableNameProcess;
+import org.jbpm.bpmn2.flow.UserTaskActorGroupModel;
+import org.jbpm.bpmn2.flow.UserTaskActorGroupProcess;
+import org.jbpm.bpmn2.flow.UserTaskActorModel;
+import org.jbpm.bpmn2.flow.UserTaskActorProcess;
+import org.jbpm.bpmn2.flow.UserTaskGroupModel;
+import org.jbpm.bpmn2.flow.UserTaskGroupProcess;
+import org.jbpm.bpmn2.flow.UserTaskModel;
+import org.jbpm.bpmn2.flow.UserTaskNoneModel;
+import org.jbpm.bpmn2.flow.UserTaskNoneProcess;
+import org.jbpm.bpmn2.flow.UserTaskProcess;
+import org.jbpm.bpmn2.flow.XORSameTargetModel;
+import org.jbpm.bpmn2.flow.XORSameTargetProcess;
 import org.jbpm.bpmn2.handler.ReceiveTaskHandler;
 import org.jbpm.bpmn2.handler.SendTaskHandler;
 import org.jbpm.bpmn2.objects.Account;
@@ -90,10 +116,6 @@ import org.jbpm.bpmn2.subprocess.CallActivityWithBoundaryEventModel;
 import org.jbpm.bpmn2.subprocess.CallActivityWithBoundaryEventProcess;
 import org.jbpm.bpmn2.subprocess.CallActivityWithIOexpressionModel;
 import org.jbpm.bpmn2.subprocess.CallActivityWithIOexpressionProcess;
-import org.jbpm.bpmn2.subprocess.ErrorsBetweenProcessModel;
-import org.jbpm.bpmn2.subprocess.ErrorsBetweenProcessProcess;
-import org.jbpm.bpmn2.subprocess.ErrorsBetweenSubProcessModel;
-import org.jbpm.bpmn2.subprocess.ErrorsBetweenSubProcessProcess;
 import org.jbpm.bpmn2.subprocess.InputMappingUsingValueModel;
 import org.jbpm.bpmn2.subprocess.InputMappingUsingValueProcess;
 import org.jbpm.bpmn2.subprocess.MainGroupAssignmentModel;
@@ -1458,7 +1480,6 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertThat(instance.status()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
 
     }
-
 
     @Test
     public void testErrorBetweenProcessesProcess() throws Exception {

--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -89,6 +89,10 @@ import org.jbpm.bpmn2.subprocess.CallActivityWithBoundaryEventModel;
 import org.jbpm.bpmn2.subprocess.CallActivityWithBoundaryEventProcess;
 import org.jbpm.bpmn2.subprocess.CallActivityWithIOexpressionModel;
 import org.jbpm.bpmn2.subprocess.CallActivityWithIOexpressionProcess;
+import org.jbpm.bpmn2.subprocess.ErrorsBetweenProcessModel;
+import org.jbpm.bpmn2.subprocess.ErrorsBetweenProcessProcess;
+import org.jbpm.bpmn2.subprocess.ErrorsBetweenSubProcessModel;
+import org.jbpm.bpmn2.subprocess.ErrorsBetweenSubProcessProcess;
 import org.jbpm.bpmn2.subprocess.InputMappingUsingValueModel;
 import org.jbpm.bpmn2.subprocess.InputMappingUsingValueProcess;
 import org.jbpm.bpmn2.subprocess.MainGroupAssignmentModel;
@@ -1454,21 +1458,23 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     }
 
+    //This test fails
     @Test
-    public void testErrorBetweenProcessesProcess() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/subprocess/BPMN2-ErrorsBetweenProcess.bpmn2",
-                "org/jbpm/bpmn2/subprocess/BPMN2-ErrorsBetweenSubProcess.bpmn2");
-
-        Map<String, Object> variables = new HashMap<>();
-
-        variables.put("tipoEvento", "error");
-        variables.put("pasoVariable", 3);
-        KogitoProcessInstance processInstance = kruntime.startProcess("ErrorsBetweenProcess", variables);
-
-        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
-        assertProcessInstanceAborted(processInstance.getStringId() + 1, kruntime);
-
-        assertProcessVarValue(processInstance, "event", "error desde Subproceso");
+    public void testErrorBetweenProcessesProcess() {
+        Application app = ProcessTestHelper.newApplication();
+        org.kie.kogito.process.Process<ErrorsBetweenSubProcessModel> errorsBetweenSubProcessProcess = ErrorsBetweenSubProcessProcess.newProcess(app);
+        ProcessInstance<ErrorsBetweenSubProcessModel> subProcessInstance = errorsBetweenSubProcessProcess
+                .createInstance(errorsBetweenSubProcessProcess.createModel());
+        org.kie.kogito.process.Process<ErrorsBetweenProcessModel> process = ErrorsBetweenProcessProcess.newProcess(app);
+        ErrorsBetweenProcessModel model = process.createModel();
+        model.setTipoEvento("error");
+        model.setPasoVariable(3);
+        ProcessInstance<ErrorsBetweenProcessModel> processInstance = process.createInstance(model);
+        processInstance.start();
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+        //expected state of sub process should be aborted. But we are getting state pending
+        assertThat(subProcessInstance.status()).isEqualTo(ProcessInstance.STATE_ABORTED);
+        Assertions.assertEquals("error desde Subproceso", processInstance.variables().getEvent());
     }
 
     @Test


### PR DESCRIPTION
In addition to previous changes associated,
Migrated test case `testErrorBetweenProcessesProcess` but the test seems to have issue where expected state of sub process should be aborted but we are getting state pending


The test can be identified by referring to Activitytest.java:
https://github.com/apache/incubator-kie-kogito-runtimes/blob/main/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java

Closes https://github.com/apache/incubator-kie-issues/issues/1131.

NOTE : This pr contains test which is yet to be resolved, commented the issues for particular tests, will update and push once resolved.