### PR TITLE
[10.0.x] NO-ISSUE: Update release utils file

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -153,7 +153,7 @@ pipeline {
                             mvnCmd.skipTests() // Conflict somehow with Python testing. If `skipTests={anyvalue}` is set, then exec plugin is not executed ...
                         }
                         if (isRelease()) {
-                            release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
+                            releaseUtils.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
                             mavenCommand.withProfiles(['apache-release'])
                         }
                         configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]) {


### PR DESCRIPTION
The release.grovvy file has been renamed to releaseUtils.groovy on [ jenkins-pipeline-shared-libraries](https://github.com/apache/incubator-kie-kogito-pipelines/tree/10.0.x/jenkins-pipeline-shared-libraries/vars). 

This PR updates the deploy job to use the new name.