### PR TITLE
[incubator-kie-issues#1441] Clean kogito-pmml-dependencies

### DIFF
--- a/drools/kogito-pmml-dependencies/pom.xml
+++ b/drools/kogito-pmml-dependencies/pom.xml
@@ -59,33 +59,33 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
       <exclusions>
+        <!-- Drools models -->
         <!-- Tree -->
         <exclusion>
           <groupId>org.kie</groupId>
-          <artifactId>kie-pmml-models-tree-model</artifactId>
+          <artifactId>kie-pmml-models-drools-tree-model</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.kie</groupId>
-          <artifactId>kie-pmml-models-tree-compiler</artifactId>
+          <artifactId>kie-pmml-models-drools-tree-compiler</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.kie</groupId>
-          <artifactId>kie-pmml-models-tree-evaluator</artifactId>
+          <artifactId>kie-pmml-models-drools-tree-evaluator</artifactId>
         </exclusion>
         <!-- Scorecard -->
         <exclusion>
           <groupId>org.kie</groupId>
-          <artifactId>kie-pmml-models-scorecard-model</artifactId>
+          <artifactId>kie-pmml-models-drools-scorecard-model</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.kie</groupId>
-          <artifactId>kie-pmml-models-scorecard-compiler</artifactId>
+          <artifactId>kie-pmml-models-drools-scorecard-compiler</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.kie</groupId>
-          <artifactId>kie-pmml-models-scorecard-evaluator</artifactId>
+          <artifactId>kie-pmml-models-drools-scorecard-evaluator</artifactId>
         </exclusion>
-
         <exclusion>
           <groupId>org.drools</groupId>
           <artifactId>drools-mvel</artifactId>
@@ -120,32 +120,31 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Drools models -->
     <!-- Tree -->
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-pmml-models-drools-tree-model</artifactId>
+      <artifactId>kie-pmml-models-tree-model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-pmml-models-drools-tree-compiler</artifactId>
+      <artifactId>kie-pmml-models-tree-compiler</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-pmml-models-drools-tree-evaluator</artifactId>
+      <artifactId>kie-pmml-models-tree-evaluator</artifactId>
     </dependency>
     <!-- Scorecard -->
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-pmml-models-drools-scorecard-model</artifactId>
+      <artifactId>kie-pmml-models-scorecard-model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-pmml-models-drools-scorecard-compiler</artifactId>
+      <artifactId>kie-pmml-models-scorecard-compiler</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-pmml-models-drools-scorecard-evaluator</artifactId>
+      <artifactId>kie-pmml-models-scorecard-evaluator</artifactId>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1441

pmml-drools implementations should be excluded from pmml dependencies.
This is a first step, but further analysis/refactoring is required

This is needed by 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


