### PR TITLE
[incubator-kie-issues#1462] Refactoring springboot integration tests configuration to avoid usage of extensions flag

### DIFF
--- a/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
@@ -141,21 +141,14 @@
           <executions>
             <execution>
               <id>kogito-generate-model</id>
-              <phase>process-resources</phase>
+              <phase>process-resources</phase> <!-- Temporary hack -->
               <goals>
                 <goal>generateModel</goal>
               </goals>
             </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.kie.kogito</groupId>
-          <artifactId>kogito-maven-plugin</artifactId>
-          <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-          <executions>
             <execution>
               <id>kogito-process-model-classes</id>
-              <phase>process-classes</phase>
+              <phase>process-classes</phase> <!-- Temporary hack -->
               <goals>
                 <goal>process-model-classes</goal>
               </goals>

--- a/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
@@ -124,12 +124,43 @@
           <configuration>
             <release>${maven.compiler.release}</release>
           </configuration>
+          <executions>
+            <execution>
+              <id>pre-kogito-generate-model</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.kie.kogito</groupId>
           <artifactId>kogito-maven-plugin</artifactId>
           <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-          <extensions>true</extensions>
+          <executions>
+            <execution>
+              <id>kogito-generate-model</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>generateModel</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.kie.kogito</groupId>
+          <artifactId>kogito-maven-plugin</artifactId>
+          <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+          <executions>
+            <execution>
+              <id>kogito-process-model-classes</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>process-model-classes</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>

--- a/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
@@ -135,21 +135,14 @@
         <executions>
           <execution>
             <id>kogito-generate-model</id>
-            <phase>process-resources</phase>
+            <phase>process-resources</phase> <!-- Temporary hack -->
             <goals>
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
-            <phase>process-classes</phase>
+            <phase>process-classes</phase> <!-- Temporary hack -->
             <goals>
               <goal>process-model-classes</goal>
             </goals>

--- a/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
@@ -118,12 +118,43 @@
         <configuration>
           <release>${maven.compiler.release}</release>
         </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
@@ -136,13 +136,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase>

--- a/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
@@ -114,12 +114,43 @@
         <configuration>
           <release>${maven.compiler.release}</release>
         </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
@@ -144,12 +144,43 @@
         <configuration>
           <release>${maven.compiler.release}</release>
         </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
@@ -166,13 +166,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-filesystem/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-filesystem/pom.xml
@@ -133,13 +133,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase> <!-- Temporary hack -->

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-filesystem/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-filesystem/pom.xml
@@ -86,7 +86,6 @@
   </dependencies>
 
   <build>
-    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -103,39 +102,54 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${version.resources.plugin}</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.parent.basedir}/integration-tests-springboot-processes-persistence-common/src/main/resources</directory>
-                  <includes>
-                    <include>**/*.bpmn</include>
-                    <include>**/*.wid</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-infinispan/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-infinispan/pom.xml
@@ -111,7 +111,6 @@
   </dependencies>
 
   <build>
-    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -128,39 +127,54 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${version.resources.plugin}</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.parent.basedir}/integration-tests-springboot-processes-persistence-common/src/main/resources</directory>
-                  <includes>
-                    <include>**/*.bpmn</include>
-                    <include>**/*.wid</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-infinispan/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-infinispan/pom.xml
@@ -158,13 +158,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase> <!-- Temporary hack -->

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-jdbc/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-jdbc/pom.xml
@@ -146,13 +146,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase> <!-- Temporary hack -->

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-jdbc/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-jdbc/pom.xml
@@ -99,7 +99,6 @@
   </dependencies>
 
   <build>
-    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -116,39 +115,54 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${version.resources.plugin}</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.parent.basedir}/integration-tests-springboot-processes-persistence-common/src/main/resources</directory>
-                  <includes>
-                    <include>**/*.bpmn</include>
-                    <include>**/*.wid</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-mongodb/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-mongodb/pom.xml
@@ -95,7 +95,6 @@
   </dependencies>
 
   <build>
-    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -112,39 +111,54 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${version.resources.plugin}</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.parent.basedir}/integration-tests-springboot-processes-persistence-common/src/main/resources</directory>
-                  <includes>
-                    <include>**/*.bpmn</include>
-                    <include>**/*.wid</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-mongodb/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-mongodb/pom.xml
@@ -142,13 +142,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase> <!-- Temporary hack -->

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-postgresql/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-postgresql/pom.xml
@@ -147,13 +147,6 @@
               <goal>generateModel</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-maven-plugin</artifactId>
-        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <executions>
           <execution>
             <id>kogito-process-model-classes</id>
             <phase>process-classes</phase> <!-- Temporary hack -->

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-postgresql/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-postgresql/pom.xml
@@ -100,7 +100,6 @@
   </dependencies>
 
   <build>
-    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
@@ -117,39 +116,54 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${version.resources.plugin}</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.parent.basedir}/integration-tests-springboot-processes-persistence-common/src/main/resources</directory>
-                  <includes>
-                    <include>**/*.bpmn</include>
-                    <include>**/*.wid</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.compiler.plugin}</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-maven-plugin</artifactId>
         <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
-        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>kogito-generate-model</id>
+            <phase>process-resources</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>generateModel</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-maven-plugin</artifactId>
+        <version>${project.version}</version> <!-- Needed, otherwise it would use the latest release found on Maven central -->
+        <executions>
+          <execution>
+            <id>kogito-process-model-classes</id>
+            <phase>process-classes</phase> <!-- Temporary hack -->
+            <goals>
+              <goal>process-model-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/pom.xml
@@ -115,6 +115,7 @@
     </dependency>
   </dependencies>
   <build>
+    <finalName>${project.artifactId}</finalName>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -128,12 +129,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.kie.kogito</groupId>
-          <artifactId>kogito-maven-plugin</artifactId>
-          <version>${project.version}</version>
-          <extensions>true</extensions>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
@@ -182,10 +177,28 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <!-- override Infinispan BOM -->
-        <version>${version.compiler.plugin}</version>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>${version.resources.plugin}</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.basedir}/src/main/resources</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.parent.basedir}/integration-tests-springboot-processes-persistence-common/src/main/resources</directory>
+                  <includes>
+                    <include>**/*.bpmn</include>
+                    <include>**/*.wid</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1462

This PR refactor the spring boot integration tests poms to avoid usage of extensions flag, redefining the lifecicle in the poms themselves.
To exactly recreate the same steps, some hack has been used
1. multiple declaration of same plugins (maven-compile-plugin and kogito-maven-plugin)
2. mapping of plugin to "wrong" phases (process-resources)

The execution order can be viewed/compared using

`mvn fr.jcgay.maven.plugins:buildplan-maven-plugin:list`

Thanks to @elguardian for pom modification suggestion

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


