### PR TITLE
[incubator-kie-issues#1467] Deleting reproducible profile and its invocation

### DIFF
--- a/.github/workflows/pr-kogito-runtimes.yml
+++ b/.github/workflows/pr-kogito-runtimes.yml
@@ -65,7 +65,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
         env:
-          BUILD_MVN_OPTS_CURRENT: '-Dreproducible -Dvalidate-formatting'
+          BUILD_MVN_OPTS_CURRENT: '-Dvalidate-formatting'
       - name: Junit Report
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/action-junit-report@main
         if: ${{ always() }}

--- a/pom.xml
+++ b/pom.xml
@@ -165,43 +165,4 @@
     <module>springboot</module>
   </modules>
 
-  <profiles>
-    <profile>
-      <id>reproducible-build</id>
-      <activation>
-        <property>
-          <name>reproducible</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-artifact-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>check-buildplan</id>
-                <goals>
-                  <goal>check-buildplan</goal>
-                </goals>
-                <!-- The execution's configuration is part of the pluginManagement. This piece here only makes sure the
-                     execution is enabled (by specifying a phase) for full profile builds. -->
-                <phase>validate</phase>
-              </execution>
-              <execution>
-                <id>compare</id>
-                <goals>
-                  <goal>compare</goal>
-                </goals>
-                <!-- The execution's configuration is part of the pluginManagement. This piece here only makes sure the
-                     execution is enabled (by specifying a phase) for full profile builds. -->
-                <phase>install</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1467

Depends on https://github.com/apache/incubator-kie-kogito-pipelines/pull/1247

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


