### PR TITLE
[incubator-kie-issues-1131] test migration from V7 to code generation-35

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -1520,7 +1520,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
 
-        Assertions.assertEquals("error desde Subproceso", processInstance.variables().getEvent());
+        assertThat(processInstance.variables().getEvent()).isEqualTo("error desde Subproceso");
     }
 
     @Test


### PR DESCRIPTION
Migrated testErrorBetweenProcessesProcess within ActivityTest.java based on the changes suggested as below,
```
Application app = ProcessTestHelper.newApplication();
        ProcessTestHelper.registerProcessEventListener(app, new DefaultKogitoProcessEventListener() {
            @Override
            public void afterProcessCompleted(ProcessCompletedEvent event) {
                if ("ErrorsBetweenSubProcess".equals(event.getProcessInstance().getProcessId())) {
                    assertThat(event.getProcessInstance().getState()).isEqualTo(ProcessInstance.STATE_ABORTED);
                }
            }
        });
        ErrorsBetweenSubProcessProcess.newProcess(app);
        org.kie.kogito.process.Process<ErrorsBetweenProcessModel> process = ErrorsBetweenProcessProcess.newProcess(app);
        ErrorsBetweenProcessModel model = process.createModel();
        model.setTipoEvento("error");
        model.setPasoVariable(3);
        ProcessInstance<ErrorsBetweenProcessModel> processInstance = process.createInstance(model);
        processInstance.start();
        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

        Assertions.assertEquals("error desde Subproceso", processInstance.variables().getEvent());
```