### PR TITLE
[incubator-kie-issues#1504] Conditionally build all or only reproducible modules based on only.reproducible flag

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -160,7 +160,9 @@ pipeline {
                         }
                         if (isRelease()) {
                             release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
-                            mavenCommand.withProfiles(['apache-release'])
+                            mavenCommand
+                            .withProfiles(['apache-release'])
+                            .withProperty('only.reproducible')
                             mavenRunClosure()
                         } else {
                             mavenRunClosure()

--- a/jbpm/pom.xml
+++ b/jbpm/pom.xml
@@ -20,26 +20,34 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-build-parent</artifactId>
-        <version>999-SNAPSHOT</version>
-        <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
+  <parent>
+    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-build-parent</artifactId>
+    <version>999-SNAPSHOT</version>
+    <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
 
-    </parent>
+  </parent>
 
-    <artifactId>jbpm</artifactId>
-    <packaging>pom</packaging>
-    <name>Kogito :: jBPM</name>
-    <description>jBPM: a Business Process Management</description>
-    <url>http://www.jbpm.org</url>
+  <artifactId>jbpm</artifactId>
+  <packaging>pom</packaging>
+  <name>Kogito :: jBPM</name>
+  <description>jBPM: a Business Process Management</description>
+  <url>http://www.jbpm.org</url>
 
-    <modules>
+  <profiles>
+    <profile>
+      <id>allSubmodules</id>
+      <activation>
+        <property>
+          <name>!only.reproducible</name>
+        </property>
+      </activation>
+      <modules>
         <module>jbpm-flow</module>
         <module>jbpm-flow-builder</module>
         <module>jbpm-bpmn2</module>
@@ -50,6 +58,28 @@
         <module>jbpm-tools</module>
         <module>jbpm-tests</module>
         <module>jbpm-deps-groups</module>
-    </modules>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>onlyReproducible</id>
+      <activation>
+        <property>
+          <name>only.reproducible</name>
+        </property>
+      </activation>
+      <modules>
+        <module>jbpm-flow</module>
+        <module>jbpm-flow-builder</module>
+        <module>jbpm-bpmn2</module>
+        <module>jbpm-flow-migration</module>
+        <module>process-serialization-protobuf</module>
+        <module>process-workitems</module>
+        <module>jbpm-usertask</module>
+        <module>jbpm-tools</module>
+        <module>jbpm-deps-groups</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -34,13 +34,39 @@
   <name>Kogito :: Spring Boot</name>
   <packaging>pom</packaging>
 
-  <modules>
-    <module>bom</module>
-    <module>addons</module>
-    <module>starters</module>
-    <module>archetype</module>
-    <module>test</module>
-    <module>integration-tests</module>
-  </modules>
+  <profiles>
+    <profile>
+      <id>allSubmodules</id>
+      <activation>
+        <property>
+          <name>!only.reproducible</name>
+        </property>
+      </activation>
+      <modules>
+        <module>bom</module>
+        <module>addons</module>
+        <module>starters</module>
+        <module>archetype</module>
+        <module>test</module>
+        <module>integration-tests</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>onlyReproducible</id>
+      <activation>
+        <property>
+          <name>only.reproducible</name>
+        </property>
+      </activation>
+      <modules>
+        <module>bom</module>
+        <module>addons</module>
+        <module>starters</module>
+        <module>archetype</module>
+        <module>test</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1504

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


