### PR TITLE
[Fix #3694] Avoid generation of fake ProcessInstanceVariableDataEvent

### DIFF
--- a/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpression.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpression.java
@@ -34,7 +34,7 @@ import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.jackson.utils.PrefixJsonNode;
 import org.kie.kogito.process.expr.Expression;
 import org.kie.kogito.serverless.workflow.utils.ExpressionHandlerUtils;
-import org.kie.kogito.serverless.workflow.utils.JsonNodeContext;
+import org.kie.kogito.serverless.workflow.utils.VariablesHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,6 +207,7 @@ public class JqExpression implements Expression {
         childScope.setValue(ExpressionHandlerUtils.SECRET_MAGIC, new PrefixJsonNode<>(ExpressionHandlerUtils::getOptionalSecret));
         childScope.setValue(ExpressionHandlerUtils.CONTEXT_MAGIC, new FunctionJsonNode(ExpressionHandlerUtils.getContextFunction(processInfo)));
         childScope.setValue(ExpressionHandlerUtils.CONST_MAGIC, ExpressionHandlerUtils.getConstants(processInfo));
+        VariablesHelper.getAdditionalVariables(processInfo).forEach(childScope::setValue);
         return childScope;
     }
 
@@ -215,8 +216,8 @@ public class JqExpression implements Expression {
             throw new IllegalArgumentException("Unable to evaluate content " + context + " using expr " + expr, validationError);
         }
         TypedOutput output = output(returnClass);
-        try (JsonNodeContext jsonNode = JsonNodeContext.from(context, processInfo)) {
-            internalExpr.apply(getScope(processInfo), jsonNode.getNode(), output);
+        try {
+            internalExpr.apply(getScope(processInfo), context, output);
             return JsonObjectUtils.convertValue(output.getResult(), returnClass);
         } catch (JsonQueryException e) {
             throw new IllegalArgumentException("Unable to evaluate content " + context + " using expr " + expr, e);

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
@@ -18,15 +18,17 @@
  */
 package org.kie.kogito.expr.jsonpath;
 
+import java.util.Map;
+
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
 import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.process.expr.Expression;
 import org.kie.kogito.serverless.workflow.utils.ExpressionHandlerUtils;
-import org.kie.kogito.serverless.workflow.utils.JsonNodeContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -61,24 +63,28 @@ public class JsonPathExpression implements Expression {
                 .build();
     }
 
+    private static boolean isContextAware(JsonNode context, Map<String, JsonNode> additionalVars) {
+        return !additionalVars.isEmpty() && context instanceof ObjectNode;
+    }
+
     private <T> T eval(JsonNode context, Class<T> returnClass, KogitoProcessContext processInfo) {
-        try (JsonNodeContext jsonNode = JsonNodeContext.from(context, processInfo)) {
-            Configuration jsonPathConfig = getConfiguration(processInfo);
-            DocumentContext parsedContext = JsonPath.using(jsonPathConfig).parse(jsonNode.getNode());
-            if (String.class.isAssignableFrom(returnClass)) {
-                StringBuilder sb = new StringBuilder();
-                // valid json path is $. or $[
-                for (String part : expr.split("((?=\\$\\.|\\$\\[))")) {
-                    JsonNode partResult = parsedContext.read(part, JsonNode.class);
-                    sb.append(partResult.isTextual() ? partResult.asText() : partResult.toPrettyString());
-                }
-                return (T) sb.toString();
-            } else {
-                Object result = parsedContext.read(expr);
-                return Boolean.class.isAssignableFrom(returnClass) && result instanceof ArrayNode ? (T) Boolean.valueOf(!((ArrayNode) result).isEmpty())
-                        : JsonObjectUtils.convertValue(jsonPathConfig.mappingProvider().map(result, returnClass, jsonPathConfig), returnClass);
+
+        Configuration jsonPathConfig = getConfiguration(processInfo);
+        DocumentContext parsedContext = JsonPath.using(jsonPathConfig).parse(context);
+        if (String.class.isAssignableFrom(returnClass)) {
+            StringBuilder sb = new StringBuilder();
+            // valid json path is $. or $[
+            for (String part : expr.split("((?=\\$\\.|\\$\\[))")) {
+                JsonNode partResult = parsedContext.read(part, JsonNode.class);
+                sb.append(partResult.isTextual() ? partResult.asText() : partResult.toPrettyString());
             }
+            return (T) sb.toString();
+        } else {
+            Object result = parsedContext.read(expr);
+            return Boolean.class.isAssignableFrom(returnClass) && result instanceof ArrayNode ? (T) Boolean.valueOf(!((ArrayNode) result).isEmpty())
+                    : JsonObjectUtils.convertValue(jsonPathConfig.mappingProvider().map(result, returnClass, jsonPathConfig), returnClass);
         }
+
     }
 
     private void assign(JsonNode context, Object value, KogitoProcessContext processInfo) {

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/WorkflowJacksonJsonNodeJsonProvider.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/WorkflowJacksonJsonNodeJsonProvider.java
@@ -18,21 +18,26 @@
  */
 package org.kie.kogito.expr.jsonpath;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
 import org.kie.kogito.jackson.utils.FunctionBaseJsonNode;
 import org.kie.kogito.jackson.utils.PrefixJsonNode;
 import org.kie.kogito.serverless.workflow.utils.ExpressionHandlerUtils;
+import org.kie.kogito.serverless.workflow.utils.VariablesHelper;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 
 public class WorkflowJacksonJsonNodeJsonProvider extends JacksonJsonNodeJsonProvider {
 
     private KogitoProcessContext context;
+    private Map<String, JsonNode> variables;
 
     public WorkflowJacksonJsonNodeJsonProvider(KogitoProcessContext context) {
         this.context = context;
+        this.variables = VariablesHelper.getAdditionalVariables(context);
     }
 
     @Override
@@ -50,7 +55,7 @@ public class WorkflowJacksonJsonNodeJsonProvider extends JacksonJsonNodeJsonProv
                 case "$" + ExpressionHandlerUtils.CONST_MAGIC:
                     return ExpressionHandlerUtils.getConstants(context);
                 default:
-                    return super.getMapValue(obj, key);
+                    return variables.containsKey(key) ? variables.get(key) : super.getMapValue(obj, key);
             }
         }
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -37,7 +37,7 @@ import org.kie.kogito.serverless.workflow.parser.FunctionNamespaceFactory;
 import org.kie.kogito.serverless.workflow.parser.FunctionTypeHandlerFactory;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.parser.VariableInfo;
-import org.kie.kogito.serverless.workflow.utils.JsonNodeContext;
+import org.kie.kogito.serverless.workflow.utils.VariablesHelper;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
@@ -181,7 +181,7 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
                 factory.subProcessNode(parserContext.newId()).name(subFlowRef.getWorkflowId()).processId(subFlowRef.getWorkflowId()).waitForCompletion(true),
                 inputVar,
                 outputVar);
-        JsonNodeContext.getEvalVariables(factory.getNode()).forEach(v -> subProcessNode.inMapping(v.getName(), v.getName()));
+        VariablesHelper.getEvalVariables(factory.getNode()).forEach(v -> subProcessNode.inMapping(v.getName(), v.getName()));
         return subProcessNode;
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/test/java/org/kie/kogito/serverless/workflow/executor/StaticFluentWorkflowApplicationTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/test/java/org/kie/kogito/serverless/workflow/executor/StaticFluentWorkflowApplicationTest.java
@@ -99,7 +99,7 @@ public class StaticFluentWorkflowApplicationTest {
     void testForEach() {
         final String SQUARE = "square";
         try (StaticWorkflowApplication application = StaticWorkflowApplication.create()) {
-            Workflow subflow = workflow("Square").start(operation().action(call(expr(SQUARE, ".input*.input"))).outputFilter(".response")).end().build();
+            Workflow subflow = workflow("Square").start(operation().action(call(expr(SQUARE, "$input*$input"))).outputFilter(".response")).end().build();
 
             Workflow workflow = workflow("ForEachTest")
                     .start(forEach(".numbers").loopVar("input").outputCollection(".result").action(subprocess(application.process(subflow)))

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/forEachCustomType.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/forEachCustomType.sw.json
@@ -22,7 +22,7 @@
           "functionRef": {
             "refName": "division",
             "arguments": {
-              "dividend": ".item",
+              "dividend": "$item",
               "divisor" : ".divisor"
              }
           }, 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/forEachRest.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/forEachRest.sw.json
@@ -22,7 +22,7 @@
           "functionRef": {
             "refName": "division",
             "arguments": {
-              "QUERY_dividend": ".item",
+              "QUERY_dividend": "$item",
               "QUERY_divisor" : ".divisor"
              }
           }, 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/foreach_child.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/foreach_child.sw.json
@@ -9,7 +9,7 @@
         {
             "name": "multiply",
             "type": "expression",
-            "operation": ".number*.constant"
+            "operation": "$number*.constant"
         }
     ],
     "states": [


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-runtimes/issues/3694
Access to loop variable in for each state is now performed as variable (using "$") rather than as property (using ".") 
To be merged with https://github.com/apache/incubator-kie-kogito-examples/pull/2019