### PR TITLE
Downgrade DefaultInstanceEventBatch trace level to debug

### DIFF
--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/DefaultInstanceEventBatch.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/DefaultInstanceEventBatch.java
@@ -68,7 +68,7 @@ public class DefaultInstanceEventBatch implements EventBatch {
 
     @Override
     public void append(Object event) {
-        LOG.info("event generated {}", event);
+        LOG.debug("event generated {}", event);
         this.dataEventAdapters.stream().filter(a -> a.accept(event)).map(a -> a.adapt(event)).forEach(this.processedEvents::add);
     }
 


### PR DESCRIPTION
Downgrade the trace level of this recurrent trace because it's very noisy 

Many thanks for submitting your Pull Request :heart:! 

