### PR TITLE
[incubator-kie-issues#1497] Using the getSerializableNodeInstances inside ProtobufProcessInstanceWriter

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.node.CompositeNode;
@@ -204,7 +205,12 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
 
     @Override
     public Collection<org.kie.api.runtime.process.NodeInstance> getNodeInstances() {
-        return new ArrayList<>(getNodeInstances(false));
+        return Collections.unmodifiableCollection(nodeInstances);
+    }
+
+    @Override
+    public Collection<org.kie.api.runtime.process.NodeInstance> getSerializableNodeInstances() {
+        return nodeInstances.stream().filter(this::isSerializable).collect(Collectors.toUnmodifiableList());
     }
 
     @Override
@@ -471,6 +477,17 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
     @Override
     public Map<String, Integer> getIterationLevels() {
         return iterationLevels;
+    }
+
+    /**
+     * Check if the given <code>org.kie.api.runtime.process.NodeInstance</code> is serializable.
+     * Every subclass should override it, if needed, to avoid polluting the parent one (this) with children details
+     * 
+     * @param toCheck
+     * @return
+     */
+    protected boolean isSerializable(org.kie.api.runtime.process.NodeInstance toCheck) {
+        return true;
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -55,7 +56,6 @@ import static org.kie.kogito.internal.process.runtime.KogitoProcessInstance.STAT
 
 /**
  * Runtime counterpart of a composite node.
- * 
  */
 public class CompositeNodeInstance extends StateBasedNodeInstance implements NodeInstanceContainer, EventNodeInstanceInterface, EventBasedNodeInstanceInterface {
 
@@ -480,14 +480,23 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
     }
 
     /**
-     * Check if the given <code>org.kie.api.runtime.process.NodeInstance</code> is serializable.
+     * Return a Set of classes that are not serializable
      * Every subclass should override it, if needed, to avoid polluting the parent one (this) with children details
-     * 
+     *
+     * @return
+     */
+    protected Set<Class<? extends org.kie.api.runtime.process.NodeInstance>> getNotSerializableClasses() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Check if the given <code>org.kie.api.runtime.process.NodeInstance</code> is serializable.
+     *
      * @param toCheck
      * @return
      */
-    protected boolean isSerializable(org.kie.api.runtime.process.NodeInstance toCheck) {
-        return true;
+    private boolean isSerializable(org.kie.api.runtime.process.NodeInstance toCheck) {
+        return !getNotSerializableClasses().contains(toCheck.getClass());
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ForEachNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ForEachNodeInstance.java
@@ -18,8 +18,15 @@
  */
 package org.jbpm.workflow.instance.node;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.variable.VariableScope;
@@ -42,7 +49,7 @@ import org.jbpm.workflow.instance.impl.MVELProcessHelper;
 import org.jbpm.workflow.instance.impl.NodeInstanceImpl;
 import org.jbpm.workflow.instance.impl.NodeInstanceResolverFactory;
 import org.kie.api.definition.process.Connection;
-import org.kie.kogito.internal.process.runtime.*;
+import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.mvel2.integration.VariableResolver;
 import org.mvel2.integration.impl.SimpleValueResolver;
 
@@ -125,11 +132,6 @@ public class ForEachNodeInstance extends CompositeContextNodeInstance {
     @Override
     public ContextContainer getContextContainer() {
         return getForEachNode().getCompositeNode();
-    }
-
-    @Override
-    public Collection<org.kie.api.runtime.process.NodeInstance> getSerializableNodeInstances() {
-        return getNodeInstances().stream().filter(this::isSerializable).collect(Collectors.toUnmodifiableList());
     }
 
     private boolean isSequential() {
@@ -351,7 +353,8 @@ public class ForEachNodeInstance extends CompositeContextNodeInstance {
         return 1;
     }
 
-    private boolean isSerializable(org.kie.api.runtime.process.NodeInstance toCheck) {
+    @Override
+    protected boolean isSerializable(org.kie.api.runtime.process.NodeInstance toCheck) {
         return !NOT_SERIALIZABLE_CLASSES.contains(toCheck.getClass());
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ForEachNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ForEachNodeInstance.java
@@ -19,7 +19,6 @@
 package org.jbpm.workflow.instance.node;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -27,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.variable.VariableScope;
@@ -59,7 +59,7 @@ import org.mvel2.integration.impl.SimpleValueResolver;
 public class ForEachNodeInstance extends CompositeContextNodeInstance {
 
     private static final long serialVersionUID = 510L;
-    private static final List<Class<? extends org.kie.api.runtime.process.NodeInstance>> NOT_SERIALIZABLE_CLASSES = Arrays.asList(ForEachJoinNodeInstance.class); // using Arrays.asList to allow multiple exclusions
+    private static final Set<Class<? extends org.kie.api.runtime.process.NodeInstance>> NOT_SERIALIZABLE_CLASSES = Set.of(ForEachJoinNodeInstance.class); // using Arrays.asList to allow multiple exclusions
 
     public static final String TEMP_OUTPUT_VAR = "foreach_output";
 
@@ -354,8 +354,8 @@ public class ForEachNodeInstance extends CompositeContextNodeInstance {
     }
 
     @Override
-    protected boolean isSerializable(org.kie.api.runtime.process.NodeInstance toCheck) {
-        return !NOT_SERIALIZABLE_CLASSES.contains(toCheck.getClass());
+    protected Set<Class<? extends org.kie.api.runtime.process.NodeInstance>> getNotSerializableClasses() {
+        return NOT_SERIALIZABLE_CLASSES;
     }
 
     private class ForEachNodeInstanceResolverFactory extends NodeInstanceResolverFactory {

--- a/jbpm/process-serialization-protobuf/src/main/java/org/jbpm/flow/serialization/impl/ProtobufProcessInstanceWriter.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/jbpm/flow/serialization/impl/ProtobufProcessInstanceWriter.java
@@ -249,7 +249,7 @@ public class ProtobufProcessInstanceWriter {
     }
 
     private <T extends NodeInstanceContainer & ContextInstanceContainer & ContextableInstance> WorkflowContext buildWorkflowContext(T nodeInstance) {
-        List<NodeInstance> nodeInstances = new ArrayList<>(nodeInstance.getNodeInstances());
+        List<NodeInstance> nodeInstances = new ArrayList<>(nodeInstance.getSerializableNodeInstances());
         List<ContextInstance> exclusiveGroupInstances = nodeInstance.getContextInstances(ExclusiveGroup.EXCLUSIVE_GROUP);
         VariableScopeInstance variableScopeInstance = (VariableScopeInstance) nodeInstance.getContextInstance(VariableScope.VARIABLE_SCOPE);
         List<Map.Entry<String, Object>> variables = (variableScopeInstance != null) ? new ArrayList<>(variableScopeInstance.getVariables().entrySet()) : Collections.emptyList();


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1497

Requires https://github.com/apache/incubator-kie-drools/pull/6116

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


