### PR TITLE
Fixing flaky test failing in multiple PRs

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -400,7 +400,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         org.kie.kogito.process.ProcessInstance<EventBasedSplit2Model> instanceTimer = processDefinition.createInstance(modelTimer);
         instanceTimer.start();
         assertThat(instanceTimer.status()).isEqualTo(org.kie.kogito.process.ProcessInstance.STATE_ACTIVE);
-        countDownListener.waitTillCompleted();
+        assertThat(countDownListener.waitTillCompleted(15000)).isTrue();
         assertThat(instanceYes.status()).isEqualTo(org.kie.kogito.process.ProcessInstance.STATE_COMPLETED);
         assertThat(instanceTimer.status()).isEqualTo(org.kie.kogito.process.ProcessInstance.STATE_COMPLETED);
     }


### PR DESCRIPTION
This  is appearing consistently in multiple PRs after merging issue [1522](https://github.com/apache/incubator-kie-issues/issues/1522)

Executing work item WorkItem 5ee6fb6f-a098-44db-b345-645d9ceb3671 [name=Human Task, state=1, processInstanceId=4239d505-5136-431a-85bb-e69ee7f4d2c7, parameters{UNIQUE_TASK_ID=_5, NodeName=Two}]
2024-10-22T15:29:09.0028304Z [ERROR] Tests run: 49, Failures: 1, Errors: 0, Skipped: 5, Time elapsed: 5.791 s <<< FAILURE! -- in org.jbpm.bpmn2.StandaloneBPMNProcessTest
2024-10-22T15:29:09.0033454Z [ERROR] org.jbpm.bpmn2.StandaloneBPMNProcessTest.testEventBasedSplit2 -- Time elapsed: 0.532 s <<< FAILURE!
2024-10-22T15:29:09.0034881Z org.opentest4j.AssertionFailedError: 
2024-10-22T15:29:09.0035522Z 
2024-10-22T15:29:09.0035868Z expected: 2
2024-10-22T15:29:09.0036528Z  but was: 1
2024-10-22T15:29:09.0037477Z 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2024-10-22T15:29:09.0039157Z 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
2024-10-22T15:29:09.0041121Z 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2024-10-22T15:29:09.0043171Z 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
2024-10-22T15:29:09.0044694Z 	at org.jbpm.bpmn2.StandaloneBPMNProcessTest.testEventBasedSplit2(StandaloneBPMNProcessTest.java:405)
2024-10-22T15:29:09.0046062Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
2024-10-22T15:29:09.0047045Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2024-10-22T15:29:09.0048211Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)