### PR TITLE
[kie-issues#1564] Do not overwrite original jar with Spring Boot executable jar in integration tests

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -1109,7 +1109,7 @@
             <executions>
               <execution>
                 <id>unpack-jar</id>
-                <phase>compile</phase>
+                <phase>process-resources</phase>
                 <goals>
                   <goal>unpack</goal>
                 </goals>

--- a/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
@@ -164,6 +164,9 @@
               <goals>
                 <goal>repackage</goal>
               </goals>
+              <configuration>
+                <classifier>executable</classifier>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
@@ -166,6 +166,9 @@
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <classifier>executable</classifier>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
@@ -154,6 +154,9 @@
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <classifier>executable</classifier>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
@@ -184,6 +184,9 @@
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <classifier>executable</classifier>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/pom.xml
@@ -128,6 +128,9 @@
               <goals>
                 <goal>repackage</goal>
               </goals>
+              <configuration>
+                <classifier>executable</classifier>
+              </configuration>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
Resolves https://github.com/apache/incubator-kie-issues/issues/1564

- Adds a classifier to Spring Boot executable jars in integration-tests. 
- Moves the unpack profile to an earlier Maven phase to make the unpacked classes available for code generation happening during compile phase. 