### PR TITLE
[Fix #3763] Properly reading compressdata string header

### DIFF
--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/process/MultipleProcessInstanceDataEvent.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/process/MultipleProcessInstanceDataEvent.java
@@ -35,8 +35,16 @@ public class MultipleProcessInstanceDataEvent extends ProcessInstanceDataEvent<C
     }
 
     public boolean isCompressed() {
-        Object extension = getExtension(MultipleProcessInstanceDataEvent.COMPRESS_DATA);
-        return extension instanceof Boolean ? ((Boolean) extension).booleanValue() : false;
+        return isCompressed(getExtension(MultipleProcessInstanceDataEvent.COMPRESS_DATA));
+    }
+
+    public static boolean isCompressed(Object extension) {
+        if (extension instanceof Boolean) {
+            return ((Boolean) extension).booleanValue();
+        } else if (extension instanceof String) {
+            return Boolean.parseBoolean((String) extension);
+        }
+        return false;
     }
 
     public void setCompressed(boolean compressed) {

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/serializer/MultipleProcessDataInstanceConverterFactory.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/serializer/MultipleProcessDataInstanceConverterFactory.java
@@ -49,8 +49,7 @@ public class MultipleProcessDataInstanceConverterFactory {
     }
 
     private static boolean isCompressed(CloudEvent event) {
-        Object value = event.getExtension(MultipleProcessInstanceDataEvent.COMPRESS_DATA);
-        return value instanceof Boolean ? ((Boolean) value).booleanValue() : false;
+        return MultipleProcessInstanceDataEvent.isCompressed(event.getExtension(MultipleProcessInstanceDataEvent.COMPRESS_DATA));
     }
 
     private static Converter<CloudEventData, Collection<ProcessInstanceDataEvent<? extends KogitoMarshallEventSupport>>> binaryConverter =


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-runtimes/issues/3763

The quarkiverse extension returns all headers as string ( see https://github.com/quarkiverse/quarkus-reactive-messaging-http/blob/main/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpCloudEventHelper.java#L106 and https://github.com/quarkiverse/quarkus-reactive-messaging-http/blob/main/runtime/src/main/java/io/quarkus/reactivemessaging/http/runtime/HttpCloudEventHelper.java#L72), so the code to identify if the byte array is compressed should be adapted to that

