### PR TITLE
kie-kogito-runtimes-3780: Disable the ADJUST_DATES_TO_CONTEXT_TIME_ZONE jackson feature in the jobs service api default deserializer

### DIFF
--- a/api/kogito-jobs-service-api/src/main/java/org/kie/kogito/jobs/service/api/serlialization/SerializationUtils.java
+++ b/api/kogito-jobs-service-api/src/main/java/org/kie/kogito/jobs/service/api/serlialization/SerializationUtils.java
@@ -54,7 +54,8 @@ public class SerializationUtils {
         ObjectMapper objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .registerModule(JsonFormat.getCloudEventJacksonModule())
-                .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(com.fasterxml.jackson.databind.DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
         registerDescriptors(objectMapper);
         return objectMapper;
     }

--- a/api/kogito-jobs-service-api/src/test/java/org/kie/kogito/jobs/service/api/event/serialization/JobCloudEventDeserializerTest.java
+++ b/api/kogito-jobs-service-api/src/test/java/org/kie/kogito/jobs/service/api/event/serialization/JobCloudEventDeserializerTest.java
@@ -150,7 +150,7 @@ class JobCloudEventDeserializerTest {
 
         assertThat(job.getSchedule()).isInstanceOf(TimerSchedule.class);
         TimerSchedule schedule = (TimerSchedule) job.getSchedule();
-        assertThat(schedule.getStartTime()).isEqualTo(SCHEDULE_START_TIME);
+        assertThat(schedule.getStartTime()).hasToString(SCHEDULE_START_TIME.toString());
         assertThat(schedule.getRepeatCount()).isEqualTo(SCHEDULE_REPEAT_COUNT);
         assertThat(schedule.getDelay()).isEqualTo(SCHEDULE_DELAY);
         assertThat(schedule.getDelayUnit()).isEqualTo(SCHEDULE_DELAY_UNIT);


### PR DESCRIPTION

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

Many thanks for submitting your Pull Request :heart:! 

<!-- Please don't forget your Issue link -->
Closes: #3780 

<!-- Please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [this configuration](https://github.com/apache/incubator-kie-kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [X] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


