### PR TITLE
Explicitly declaring xstream to override a transitively imported version affected by CVE 

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -155,6 +155,7 @@
     <version.com.google.collections>1.0</version.com.google.collections>
     <version.com.google.guava>33.0.0-jre</version.com.google.guava>
     <version.apache.commons.commons-compress>1.26.1</version.apache.commons.commons-compress>
+    <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
   </properties>
 
   <dependencyManagement>
@@ -451,13 +452,13 @@
         <version>${version.jakarta.persistence-api}</version>
       </dependency>
 
-
       <!-- Temporary excluding xstream, current Quarkus version is importing a version (1.4.20) affected by CVE
            When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.21</version>
+        <scope>test</scope>
+        <version>${version.com.thoughtworks.xstream}</version>
       </dependency>
 
       <dependency>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -457,7 +457,6 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <scope>test</scope>
         <version>${version.com.thoughtworks.xstream}</version>
       </dependency>
 

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -155,6 +155,8 @@
     <version.com.google.collections>1.0</version.com.google.collections>
     <version.com.google.guava>33.0.0-jre</version.com.google.guava>
     <version.apache.commons.commons-compress>1.26.1</version.apache.commons.commons-compress>
+    <!-- Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE
+     When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
   </properties>
 
@@ -452,7 +454,7 @@
         <version>${version.jakarta.persistence-api}</version>
       </dependency>
 
-      <!-- Temporary excluding xstream, current Quarkus version is importing a version (1.4.20) affected by CVE
+      <!-- Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE
            When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -451,6 +451,20 @@
         <version>${version.jakarta.persistence-api}</version>
       </dependency>
 
+
+      <!-- To be removed after upgrading to Quarkus 3.15.x -->
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-junit5</artifactId>
+        <version>${version.io.quarkus}</version>
+        <exclusions>
+          <exclusion>
+              <groupId>com.thoughtworks.xstream</groupId>
+              <artifactId>xstream</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -452,7 +452,8 @@
       </dependency>
 
 
-      <!-- To be removed after upgrading to Quarkus 3.15.x -->
+      <!-- Temporary excluding xstream, current Quarkus version is importing a version (1.4.20) affected by CVE
+           When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-junit5</artifactId>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -455,15 +455,9 @@
       <!-- Temporary excluding xstream, current Quarkus version is importing a version (1.4.20) affected by CVE
            When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
       <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-junit5</artifactId>
-        <version>${version.io.quarkus}</version>
-        <exclusions>
-          <exclusion>
-              <groupId>com.thoughtworks.xstream</groupId>
-              <artifactId>xstream</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>1.4.21</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE