### PR TITLE
[incubator-kie-issues-1682] Add kafka network alias

### DIFF
--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKafkaContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKafkaContainer.java
@@ -47,6 +47,7 @@ public class KogitoKafkaContainer extends KogitoGenericContainer<KogitoKafkaCont
         withExposedPorts(KAFKA_PORT);
         withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("sh"));
         withCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        withNetworkAliases("kafka");
         waitingFor(Wait.forLogMessage(".*Started Kafka API server.*", 1).withStartupTimeout(Constants.CONTAINER_START_TIMEOUT));
     }
 


### PR DESCRIPTION
Missing to add "kafka" as network alias for some tests at kogito-apps

Related to https://github.com/apache/incubator-kie-issues/issues/1682