### PR TITLE
[incubator-kie-issues#1775] Springboot apps - Conditionally overwrite code-related context properties only if twin system properties are not null

### DIFF
--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
@@ -73,19 +73,19 @@ public abstract class AbstractKieMojo extends AbstractMojo {
     @Parameter(required = true, defaultValue = "${project.basedir}")
     protected File baseDir;
 
-    @Parameter(property = "kogito.codegen.persistence", defaultValue = "true")
+    @Parameter(property = "kogito.codegen.persistence")
     protected boolean persistence;
 
-    @Parameter(property = "kogito.codegen.rules", defaultValue = "true")
+    @Parameter(property = "kogito.codegen.rules")
     protected String generateRules;
 
-    @Parameter(property = "kogito.codegen.processes", defaultValue = "true")
+    @Parameter(property = "kogito.codegen.processes")
     protected String generateProcesses;
 
-    @Parameter(property = "kogito.codegen.decisions", defaultValue = "true")
+    @Parameter(property = "kogito.codegen.decisions")
     protected String generateDecisions;
 
-    @Parameter(property = "kogito.codegen.predictions", defaultValue = "true")
+    @Parameter(property = "kogito.codegen.predictions")
     protected String generatePredictions;
 
     private Reflections reflections;
@@ -174,11 +174,21 @@ public abstract class AbstractKieMojo extends AbstractMojo {
             }
         });
 
-        context.setApplicationProperty(Generator.CONFIG_PREFIX + RuleCodegen.GENERATOR_NAME, generateRules);
-        context.setApplicationProperty(Generator.CONFIG_PREFIX + ProcessCodegen.GENERATOR_NAME, generateProcesses);
-        context.setApplicationProperty(Generator.CONFIG_PREFIX + PredictionCodegen.GENERATOR_NAME, generatePredictions);
-        context.setApplicationProperty(Generator.CONFIG_PREFIX + DecisionCodegen.GENERATOR_NAME, generateDecisions);
-        context.setApplicationProperty(Generator.CONFIG_PREFIX + PersistenceGenerator.GENERATOR_NAME, Boolean.toString(persistence));
+        overwritePropertiesIfNeeded(context);
+    }
+
+    void overwritePropertiesIfNeeded(KogitoBuildContext context) {
+        overwritePropertyIfNeeded(context, RuleCodegen.GENERATOR_NAME, generateRules);
+        overwritePropertyIfNeeded(context, ProcessCodegen.GENERATOR_NAME, generateProcesses);
+        overwritePropertyIfNeeded(context, PredictionCodegen.GENERATOR_NAME, generatePredictions);
+        overwritePropertyIfNeeded(context, DecisionCodegen.GENERATOR_NAME, generateDecisions);
+        overwritePropertyIfNeeded(context, PersistenceGenerator.GENERATOR_NAME, Boolean.toString(persistence));
+    }
+
+    static void overwritePropertyIfNeeded(KogitoBuildContext context, String generatorName, String propertyValue) {
+        if (propertyValue != null && !propertyValue.isEmpty()) {
+            context.setApplicationProperty(Generator.CONFIG_PREFIX + generatorName, propertyValue);
+        }
     }
 
     private KogitoBuildContext.Builder contextBuilder() {

--- a/kogito-maven-plugin/src/test/java/org/kie/kogito/maven/plugin/AbstractKieMojoTest.java
+++ b/kogito-maven-plugin/src/test/java/org/kie/kogito/maven/plugin/AbstractKieMojoTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.kie.kogito.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.kogito.codegen.api.Generator;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.codegen.decision.DecisionCodegen;
+import org.kie.kogito.codegen.prediction.PredictionCodegen;
+import org.kie.kogito.codegen.process.ProcessCodegen;
+import org.kie.kogito.codegen.process.persistence.PersistenceGenerator;
+import org.kie.kogito.codegen.rules.RuleCodegen;
+
+import static org.kie.kogito.maven.plugin.AbstractKieMojo.overwritePropertyIfNeeded;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class AbstractKieMojoTest {
+
+    private static final List<String> generatorNames;
+
+    static {
+        generatorNames = new ArrayList<>();
+        generatorNames.add(RuleCodegen.GENERATOR_NAME);
+        generatorNames.add(ProcessCodegen.GENERATOR_NAME);
+        generatorNames.add(PredictionCodegen.GENERATOR_NAME);
+        generatorNames.add(DecisionCodegen.GENERATOR_NAME);
+        generatorNames.add(PersistenceGenerator.GENERATOR_NAME);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getGeneratorNamesStream")
+    void overwritePropertiesIfNeededWithNull(String generatorName) {
+        String expectedWrittenProperty = Generator.CONFIG_PREFIX + generatorName;
+        AbstractKieMojo abstractKieMojo = new AbstractKieMojo() {
+            @Override
+            public void execute() throws MojoExecutionException, MojoFailureException {
+            }
+        };
+        KogitoBuildContext kogitoBuildContextMocked = mock(KogitoBuildContext.class);
+        abstractKieMojo.overwritePropertiesIfNeeded(kogitoBuildContextMocked);
+        if (generatorName.equals(PersistenceGenerator.GENERATOR_NAME)) {
+            verify(kogitoBuildContextMocked, times(1)).setApplicationProperty(expectedWrittenProperty, "false"); // being a boolean property, it default to false
+        } else {
+            verify(kogitoBuildContextMocked, never()).setApplicationProperty(eq(expectedWrittenProperty), any());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getGeneratorNamesStream")
+    void overwritePropertyIfNeededWithNotNull(String generatorName) {
+        String propertyValue = "notnull";
+        String expectedWrittenProperty = Generator.CONFIG_PREFIX + generatorName;
+        KogitoBuildContext kogitoBuildContextMocked = mock(KogitoBuildContext.class);
+        overwritePropertyIfNeeded(kogitoBuildContextMocked, generatorName, propertyValue);
+        verify(kogitoBuildContextMocked, times(1)).setApplicationProperty(expectedWrittenProperty, propertyValue);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getGeneratorNamesStream")
+    void overwritePropertyIfNeededWithEmpty(String generatorName) {
+        String propertyValue = "";
+        String expectedWrittenProperty = Generator.CONFIG_PREFIX + generatorName;
+        KogitoBuildContext kogitoBuildContextMocked = mock(KogitoBuildContext.class);
+        overwritePropertyIfNeeded(kogitoBuildContextMocked, generatorName, propertyValue);
+        verify(kogitoBuildContextMocked, never()).setApplicationProperty(expectedWrittenProperty, propertyValue);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getGeneratorNamesStream")
+    void overwritePropertyIfNeededWithNull(String generatorName) {
+        String propertyValue = null;
+        String expectedWrittenProperty = Generator.CONFIG_PREFIX + generatorName;
+        KogitoBuildContext kogitoBuildContextMocked = mock(KogitoBuildContext.class);
+        overwritePropertyIfNeeded(kogitoBuildContextMocked, generatorName, propertyValue);
+        verify(kogitoBuildContextMocked, never()).setApplicationProperty(expectedWrittenProperty, propertyValue);
+    }
+
+    static Stream<String> getGeneratorNamesStream() {
+        return generatorNames.stream();
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1775

This PR:
1. overwrite the code-gen context properties only if related system properties are not null/empty
2. unit test newly added methods/checks

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


