### PR TITLE
[incubator-kie-issues#1737] [CVE] [Medium] CVE-2023-0833 okhttp-3.12.12.jar (Part 2)

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -80,6 +80,7 @@
     Kubernetes addons since they use a different version.
     -->
     <version.io.fabric8.kubernetes-client>6.10.0</version.io.fabric8.kubernetes-client>
+    <version.com.squareup.okhttp3>4.12.0</version.com.squareup.okhttp3>
     <version.io.micrometer>1.12.2</version.io.micrometer>
     <version.org.flywaydb>9.22.3</version.org.flywaydb>
     <version.org.postgresql>42.7.2</version.org.postgresql>
@@ -248,6 +249,12 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>${version.ch.qos.logback}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${version.com.squareup.okhttp3}</version>
       </dependency>
 
       <!-- Java 17 compatibility -->


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/1781

GroupId: com.squareup.okhttp3
ArtifactId: okhttp
Version: 3.12.12

Description: A flaw was found in Red Hat's AMQ-Streams, which ships a version of the OKHttp component with an information disclosure flaw via an exception triggered by a header containing an illegal value. This issue could allow an authenticated attacker to access information outside of their regular permissions.

Top fix: Upgrade to version com.squareup.okhttp3:okhttp:4.9.2
Message: Upgrade to version