### PR TITLE
[NO-ISSUE][DEP UPDATE] Updating logback to 1.5.16

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -68,7 +68,7 @@
     <version.com.sun.activation>2.0.1</version.com.sun.activation>
     <version.javax.inject>2.0.1</version.javax.inject>
     <version.org.eclipse.microprofile.openapi>3.1.1</version.org.eclipse.microprofile.openapi>
-    <version.ch.qos.logback>1.4.14</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
     <version.jakarta.annotation-api>2.1.1</version.jakarta.annotation-api>
     <version.jakarta.validation-api>3.0.2</version.jakarta.validation-api>
     <version.jakarta.xml.bind-api>4.0.1</version.jakarta.xml.bind-api>

--- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
@@ -99,6 +99,7 @@
             <artifactId>kogito-drools</artifactId>
             <scope>test</scope>
         </dependency>
+        
     </dependencies>
 
 </project>

--- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
@@ -99,7 +99,7 @@
             <artifactId>kogito-drools</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
 
 </project>

--- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
@@ -99,11 +99,6 @@
             <artifactId>kogito-drools</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.drools</groupId>
-            <artifactId>drools-codegen-common</artifactId>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
@@ -99,6 +99,10 @@
             <artifactId>kogito-drools</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-codegen-common</artifactId>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Follow-up for https://github.com/apache/incubator-kie-issues/issues/1787. We're updating SpringBoot, which is using LogBack 1.5.16. It makes sense to keep the versions the same everywhere.

See also:
https://github.com/apache/incubator-kie-tools/pull/2884
https://github.com/apache/incubator-kie-drools/pull/6236