### PR TITLE
[Fix #3813] Removing Quarkus Configuration From Springboot file

### DIFF
--- a/springboot/integration-tests/integration-tests-springboot-kafka-it/src/main/resources/application.properties
+++ b/springboot/integration-tests/integration-tests-springboot-kafka-it/src/main/resources/application.properties
@@ -30,5 +30,5 @@ kogito.addon.cloudevents.kafka.kogito_incoming_stream=pingpong
 
 # Kogito events
 kogito.addon.events.process.kafka.kogito-processinstances-events.topic=kogito-processinstances-events
-kogito.addon.events.process.kafka.kogito-processdefinitions-events.topic=kogito-processdefinitions-events 
+kogito.addon.events.process.kafka.kogito-processdefinitions-events.topic=kogito-processdefinitions-events
 kogito.addon.events.process.kafka.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events

--- a/springboot/integration-tests/integration-tests-springboot-kafka-it/src/main/resources/application.properties
+++ b/springboot/integration-tests/integration-tests-springboot-kafka-it/src/main/resources/application.properties
@@ -27,13 +27,8 @@ spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.Str
 # read/write on the same topic
 kogito.addon.cloudevents.kafka.kogito_outgoing_stream=pingpong
 kogito.addon.cloudevents.kafka.kogito_incoming_stream=pingpong
+
 # Kogito events
-mp.messaging.outgoing.kogito-processinstances-events.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-processinstances-events.topic=kogito-processinstances-events
-mp.messaging.outgoing.kogito-processinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.kogito-usertaskinstances-events.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events
-mp.messaging.outgoing.kogito-usertaskinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.outgoing.kogito-variables-events.connector=smallrye-kafka
-mp.messaging.outgoing.kogito-variables-events.topic=kogito-variables-events
-mp.messaging.outgoing.kogito-variables-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+kogito.addon.events.process.kafka.kogito-processinstances-events.topic=kogito-processinstances-events
+kogito.addon.events.process.kafka.kogito-processdefinitions-events.topic=kogito-processdefinitions-events 
+kogito.addon.events.process.kafka.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events


### PR DESCRIPTION
As part of resolution of  https://github.com/apache/incubator-kie-kogito-runtimes/issues/3813, a misleading application.properties should be changed

