### PR TITLE
[incubator-kie-issues#1812] Restore source dumping from kogito-maven-plugin

### DIFF
--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +36,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.drools.codegen.common.AppPaths;
 import org.drools.codegen.common.DroolsModelBuildContext;
-import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileWriter;
 import org.kie.kogito.KogitoGAV;
 import org.kie.kogito.codegen.api.Generator;
@@ -266,20 +264,6 @@ public abstract class AbstractKieMojo extends AbstractMojo {
         } catch (Exception e) {
             return false;
         }
-    }
-
-    protected void writeGeneratedFiles(Collection<GeneratedFile> generatedFiles) {
-        GeneratedFileWriter writer = getGeneratedFileWriter();
-        generatedFiles.forEach(generatedFile -> writeGeneratedFile(generatedFile, writer));
-    }
-
-    protected void writeGeneratedFile(GeneratedFile generatedFile) {
-        writeGeneratedFile(generatedFile, getGeneratedFileWriter());
-    }
-
-    protected void writeGeneratedFile(GeneratedFile generatedFile, GeneratedFileWriter writer) {
-        getLog().info("Generating: " + generatedFile.relativePath());
-        writer.write(generatedFile);
     }
 
     protected File getSourcesPath() {

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/util/CompilerHelper.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/util/CompilerHelper.java
@@ -58,16 +58,20 @@ public class CompilerHelper {
                 File pathFile = new File(path);
                 settings.addClasspath(pathFile);
             }
-            // Compile and write persistence files
             compileAndWriteClasses(generatedSources, classLoader, settings, getGeneratedFileWriter(baseDir), log);
+            writeFiles(generatedSources, baseDir, log);
         } catch (Exception e) {
             throw new MojoExecutionException("Error during processing model classes", e);
         }
     }
 
-    public static void dumpResources(Collection<GeneratedFile> generatedFiles, File baseDir, Log log) {
+    public static void dumpResources(Collection<GeneratedFile> resources, File baseDir, Log log) {
+        writeFiles(resources, baseDir, log);
+    }
+
+    static void writeFiles(Collection<GeneratedFile> toWrite, File baseDir, Log log) {
         GeneratedFileWriter writer = getGeneratedFileWriter(baseDir);
-        generatedFiles.forEach(generatedFile -> writeGeneratedFile(generatedFile, writer, log));
+        toWrite.forEach(generatedFile -> writeGeneratedFile(generatedFile, writer, log));
     }
 
     static void writeGeneratedFile(GeneratedFile generatedFile, GeneratedFileWriter writer, Log log) {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1812



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


