### PR TITLE
[NO_ISSUE] Fix netty-related CVE. Unify versions

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -73,6 +73,9 @@
     <version.jakarta.validation-api>3.0.2</version.jakarta.validation-api>
     <version.jakarta.xml.bind-api>4.0.1</version.jakarta.xml.bind-api>
 
+    <!--This needs to be in sync with quarkus one-->
+    <version.io.netty>4.1.115.Final</version.io.netty>
+
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
     <!--
     We add Fabric8 here to use as a basis for Addons/Kubernetes
@@ -420,6 +423,17 @@
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
         <version>${version.io.smallrye.reactive.mutiny-vertx-web-client}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${version.io.netty}</version>
       </dependency>
 
       <!-- metrics - monitoring -->

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -73,8 +73,7 @@
     <version.jakarta.validation-api>3.0.2</version.jakarta.validation-api>
     <version.jakarta.xml.bind-api>4.0.1</version.jakarta.xml.bind-api>
 
-    <!--This needs to be in sync with quarkus one-->
-    <version.io.netty>4.1.115.Final</version.io.netty>
+    <version.io.netty>4.1.118.Final</version.io.netty>
 
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
     <!--


### PR DESCRIPTION
Unify netty-handler and netty-common versions to 4.1.115-Final - the one used by quarkus

Requires https://github.com/apache/incubator-kie-drools/pull/6263

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


