### PR TITLE
[kie-issues#1850] update the version of smallrye-mutiny-vertx-web-client to 3.17.1.

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -90,7 +90,7 @@
     <version.io.smallrye-open-api>3.10.0</version.io.smallrye-open-api>
     <version.org.awaitility>4.2.0</version.org.awaitility>
 
-    <version.io.smallrye.reactive.mutiny-vertx-web-client>3.11.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
+    <version.io.smallrye.reactive.mutiny-vertx-web-client>3.17.1</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
     <version.io.vertx>4.5.11</version.io.vertx>
     <version.io.grpc>1.65.1</version.io.grpc>


### PR DESCRIPTION
The current version of the netty-codec-http dependency (4.1.107.Final) used in the kogito-runtimes repository contains a CVE vulnerability. This vulnerability is being introduced transitively via the io.smallrye.reactive.mutiny-vertx-web-client dependency. To mitigate this issue, update the version of smallrye-mutiny-vertx-web-client to 3.17.1.

Closes: https://github.com/apache/incubator-kie-issues/issues/1850