### PR TITLE
[NO_ISSUE] Provide DataBaseInfo.toString method

### DIFF
--- a/addons/common/flyway/src/main/java/org/kie/flyway/initializer/db/DataBaseInfo.java
+++ b/addons/common/flyway/src/main/java/org/kie/flyway/initializer/db/DataBaseInfo.java
@@ -48,4 +48,8 @@ public class DataBaseInfo {
         String[] fragments = name.split(NORMALIZATION_REGEX);
         return String.join("-", fragments).toLowerCase();
     }
+
+    public String toString() {
+        return "DataBaseInfo [name=" + name + ", version=" + version + ", normalizedName=" + normalizedName + "]";
+    }
 }


### PR DESCRIPTION
Add toString method to DataBaseInfo class in order to make the logs more readable:

BEFORE:
```
WARN  [org.kie.flyway.initializer.KieFlywayInitializer:95] (main) Cannot run Flyway migration for module `jbpm-user-task-storage`, cannot find SQL Script locations for db `org.kie.flyway.initializer.db.DataBaseInfo@56193e3a`
```

AFTER:
```
WARN  [org.kie.flyway.initializer.KieFlywayInitializer:95] (main) Cannot run Flyway migration for module `jbpm-user-task-storage`, cannot find SQL Script locations for db `DataBaseInfo [name=Microsoft SQL Server, version=16.00.4135, normalizedName=microsoft-sql-server]`
```
