### PR TITLE
[incubator-kie-issues#1858] Fixed missing data in jobs associated with User Tasks Part 1

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescription.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescription.java
@@ -27,16 +27,29 @@ public class UserTaskInstanceJobDescription implements JobDescription {
     private ExpirationTime expirationTime;
     private Integer priority = ProcessInstanceJobDescription.DEFAULT_PRIORITY;
     private String userTaskInstanceId;
+    private String processId;
+    private String processInstanceId;
+    private String nodeInstanceId;
 
     public UserTaskInstanceJobDescription() {
         // do nothing
     }
 
-    public UserTaskInstanceJobDescription(String id, ExpirationTime expirationTime, Integer priority, String userTaskInstanceId) {
+    public UserTaskInstanceJobDescription(
+            String id,
+            ExpirationTime expirationTime,
+            Integer priority,
+            String userTaskInstanceId,
+            String processId,
+            String processInstanceId,
+            String nodeInstanceId) {
         this.id = id;
         this.expirationTime = expirationTime;
         this.priority = priority;
         this.userTaskInstanceId = userTaskInstanceId;
+        this.processId = processId;
+        this.processInstanceId = processInstanceId;
+        this.nodeInstanceId = nodeInstanceId;
     }
 
     @Override
@@ -59,8 +72,20 @@ public class UserTaskInstanceJobDescription implements JobDescription {
         return null;
     }
 
-    public String getUserTaskInstanceId() {
+    public String userTaskInstanceId() {
         return userTaskInstanceId;
+    }
+
+    public String processId() {
+        return processId;
+    }
+
+    public String processInstanceId() {
+        return processInstanceId;
+    }
+
+    public String nodeInstanceId() {
+        return nodeInstanceId;
     }
 
     public static UserTaskInstanceJobDescriptionBuilder newUserTaskInstanceJobDescriptionBuilder() {

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescription.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescription.java
@@ -30,6 +30,8 @@ public class UserTaskInstanceJobDescription implements JobDescription {
     private String processId;
     private String processInstanceId;
     private String nodeInstanceId;
+    private String rootProcessInstanceId;
+    private String rootProcessId;
 
     public UserTaskInstanceJobDescription() {
         // do nothing
@@ -42,7 +44,9 @@ public class UserTaskInstanceJobDescription implements JobDescription {
             String userTaskInstanceId,
             String processId,
             String processInstanceId,
-            String nodeInstanceId) {
+            String nodeInstanceId,
+            String rootProcessInstanceId,
+            String rootProcessId) {
         this.id = id;
         this.expirationTime = expirationTime;
         this.priority = priority;
@@ -50,6 +54,8 @@ public class UserTaskInstanceJobDescription implements JobDescription {
         this.processId = processId;
         this.processInstanceId = processInstanceId;
         this.nodeInstanceId = nodeInstanceId;
+        this.rootProcessInstanceId = rootProcessInstanceId;
+        this.rootProcessId = rootProcessId;
     }
 
     @Override
@@ -86,6 +92,14 @@ public class UserTaskInstanceJobDescription implements JobDescription {
 
     public String nodeInstanceId() {
         return nodeInstanceId;
+    }
+
+    public String rootProcessInstanceId() {
+        return rootProcessInstanceId;
+    }
+
+    public String rootProcessId() {
+        return rootProcessId;
     }
 
     public static UserTaskInstanceJobDescriptionBuilder newUserTaskInstanceJobDescriptionBuilder() {

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescriptionBuilder.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescriptionBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.jobs.descriptors;
 
+import java.util.Map;
 import java.util.UUID;
 
 import org.kie.kogito.jobs.ExpirationTime;
@@ -28,9 +29,7 @@ public class UserTaskInstanceJobDescriptionBuilder {
     private ExpirationTime expirationTime;
     private Integer priority = ProcessInstanceJobDescription.DEFAULT_PRIORITY;
     private String userTaskInstanceId;
-    private String processId;
-    private String processInstanceId;
-    private String nodeInstanceId;
+    private Map<String, Object> metadata;
 
     public UserTaskInstanceJobDescriptionBuilder id(String id) {
         this.id = id;
@@ -56,22 +55,21 @@ public class UserTaskInstanceJobDescriptionBuilder {
         return this;
     }
 
-    public UserTaskInstanceJobDescriptionBuilder processId(String processId) {
-        this.processId = processId;
-        return this;
-    }
-
-    public UserTaskInstanceJobDescriptionBuilder processInstanceId(String processInstanceId) {
-        this.processInstanceId = processInstanceId;
-        return this;
-    }
-
-    public UserTaskInstanceJobDescriptionBuilder nodeInstanceId(String nodeInstanceId) {
-        this.nodeInstanceId = nodeInstanceId;
+    public UserTaskInstanceJobDescriptionBuilder metadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
         return this;
     }
 
     public UserTaskInstanceJobDescription build() {
-        return new UserTaskInstanceJobDescription(id, expirationTime, priority, userTaskInstanceId, processId, processInstanceId, nodeInstanceId);
+        return new UserTaskInstanceJobDescription(
+                id,
+                expirationTime,
+                priority,
+                userTaskInstanceId,
+                (String) this.metadata.get("ProcessId"),
+                (String) this.metadata.get("ProcessInstanceId"),
+                (String) this.metadata.get("NodeInstanceId"),
+                (String) this.metadata.get("RootProcessInstanceId"),
+                (String) this.metadata.get("RootProcessId"));
     }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescriptionBuilder.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/descriptors/UserTaskInstanceJobDescriptionBuilder.java
@@ -21,34 +21,16 @@ package org.kie.kogito.jobs.descriptors;
 import java.util.UUID;
 
 import org.kie.kogito.jobs.ExpirationTime;
-import org.kie.kogito.jobs.JobDescription;
 
-public class UserTaskInstanceJobDescriptionBuilder implements JobDescription {
+public class UserTaskInstanceJobDescriptionBuilder {
 
     private String id;
     private ExpirationTime expirationTime;
     private Integer priority = ProcessInstanceJobDescription.DEFAULT_PRIORITY;
     private String userTaskInstanceId;
-
-    @Override
-    public String id() {
-        return id;
-    }
-
-    @Override
-    public ExpirationTime expirationTime() {
-        return expirationTime;
-    }
-
-    @Override
-    public Integer priority() {
-        return priority;
-    }
-
-    @Override
-    public String path() {
-        return null;
-    }
+    private String processId;
+    private String processInstanceId;
+    private String nodeInstanceId;
 
     public UserTaskInstanceJobDescriptionBuilder id(String id) {
         this.id = id;
@@ -74,7 +56,22 @@ public class UserTaskInstanceJobDescriptionBuilder implements JobDescription {
         return this;
     }
 
+    public UserTaskInstanceJobDescriptionBuilder processId(String processId) {
+        this.processId = processId;
+        return this;
+    }
+
+    public UserTaskInstanceJobDescriptionBuilder processInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+        return this;
+    }
+
+    public UserTaskInstanceJobDescriptionBuilder nodeInstanceId(String nodeInstanceId) {
+        this.nodeInstanceId = nodeInstanceId;
+        return this;
+    }
+
     public UserTaskInstanceJobDescription build() {
-        return new UserTaskInstanceJobDescription(id, expirationTime, priority, userTaskInstanceId);
+        return new UserTaskInstanceJobDescription(id, expirationTime, priority, userTaskInstanceId, processId, processInstanceId, nodeInstanceId);
     }
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/jobs/impl/InMemoryUserTaskJobExecutorFactory.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/jobs/impl/InMemoryUserTaskJobExecutorFactory.java
@@ -94,7 +94,7 @@ class SignalUserTaskInstanceOnExpiredTimer implements Runnable {
     @Override
     public void run() {
         String jobId = userTaskInstanceJobDescription.id();
-        String userTaskInstanceId = userTaskInstanceJobDescription.getUserTaskInstanceId();
+        String userTaskInstanceId = userTaskInstanceJobDescription.userTaskInstanceId();
         try {
             Optional<UserTaskInstance> userTaskInstance = jobsConfiguration.userTasks().instances().findById(userTaskInstanceId);
             if (userTaskInstance.isEmpty()) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -614,6 +614,8 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
                         .processInstanceId(getStringId())
                         .processId(getProcessId())
                         .nodeInstanceId(nodeInstanceId)
+                        .rootProcessId(getRootProcessId())
+                        .rootProcessInstanceId(getRootProcessInstanceId())
                         .build();
         JobsService jobsService = InternalProcessRuntime.asKogitoProcessRuntime(getKnowledgeRuntime().getProcessRuntime()).getJobsService();
         jobsService.scheduleJob(description);

--- a/jbpm/jbpm-usertask-workitem/src/main/java/org/kie/kogito/jbpm/usertask/handler/UserTaskKogitoWorkItemHandler.java
+++ b/jbpm/jbpm-usertask-workitem/src/main/java/org/kie/kogito/jbpm/usertask/handler/UserTaskKogitoWorkItemHandler.java
@@ -98,6 +98,7 @@ public class UserTaskKogitoWorkItemHandler extends DefaultKogitoWorkItemHandler 
         instance.setMetadata("RootProcessId", workItem.getProcessInstance().getRootProcessId());
         instance.setMetadata("RootProcessInstanceId", workItem.getProcessInstance().getRootProcessInstanceId());
         instance.setMetadata("ParentProcessInstanceId", workItem.getProcessInstance().getParentProcessInstanceId());
+        instance.setMetadata("NodeInstanceId", workItem.getNodeInstance().getId());
 
         instance.fireInitialStateChange();
         workItem.getParameters().entrySet().stream().filter(e -> !HumanTaskNode.TASK_PARAMETERS.contains(e.getKey())).forEach(e -> instance.setInput(e.getKey(), e.getValue()));

--- a/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/DefaultUserTaskInstance.java
+++ b/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/DefaultUserTaskInstance.java
@@ -688,9 +688,7 @@ public class DefaultUserTaskInstance implements UserTaskInstance {
                     .generateId()
                     .expirationTime(expirationTime)
                     .userTaskInstanceId(this.id)
-                    .processId((String) this.metadata.get("ProcessId"))
-                    .processInstanceId((String) this.metadata.get("ProcessInstanceId"))
-                    .nodeInstanceId((String) this.metadata.get("NodeInstanceId"))
+                    .metadata(this.metadata)
                     .build());
         }
         return jobs;

--- a/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/DefaultUserTaskInstance.java
+++ b/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/DefaultUserTaskInstance.java
@@ -688,6 +688,9 @@ public class DefaultUserTaskInstance implements UserTaskInstance {
                     .generateId()
                     .expirationTime(expirationTime)
                     .userTaskInstanceId(this.id)
+                    .processId((String) this.metadata.get("ProcessId"))
+                    .processInstanceId((String) this.metadata.get("ProcessInstanceId"))
+                    .nodeInstanceId((String) this.metadata.get("NodeInstanceId"))
                     .build());
         }
         return jobs;


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/1858

The Jobs scheduled by the UserTask Subsystem when registering the Deadlines/Reassignments are lacking of some fields processId, processInsanceId and nodeInstanceId when indexed in data-index. 

Ensemble:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/3857
https://github.com/apache/incubator-kie-kogito-apps/pull/2203