### PR TITLE
Including Python modules in regular build (but not IT)

### DIFF
--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -61,21 +61,8 @@
     <module>process-definitions</module>
     <module>dynamic</module>
     <module>jbpm-usertask-storage-jpa</module>
+    <module>python</module>
   </modules>
-
-  <profiles>
-    <profile>
-      <id>full</id>
-      <activation>
-        <property>
-          <name>full</name>
-        </property>
-      </activation>
-      <modules>
-        <module>python</module>
-       </modules>
-     </profile>
-  </profiles>
 
   <build>
     <pluginManagement>

--- a/quarkus/addons/python/integration-tests/pom.xml
+++ b/quarkus/addons/python/integration-tests/pom.xml
@@ -136,7 +136,9 @@
                 <executable>pip</executable>
                 <arguments>
                     <argument>install</argument>
-                    <argument>jep==4.2.0</argument>
+                    <argument>--no-cache-dir</argument> 
+                    <arguemnt>--no-build-isolation</arguemnt>
+                    <argument>jep==4.2.2</argument>
                 </arguments>
             </configuration>
           </execution>

--- a/quarkus/addons/python/pom.xml
+++ b/quarkus/addons/python/pom.xml
@@ -33,6 +33,20 @@
   <modules>
     <module>deployment</module>
     <module>runtime</module>
-    <module>integration-tests</module>
   </modules>
+  
+   <profiles>
+    <profile>
+      <id>full</id>
+      <activation>
+        <property>
+          <name>full</name>
+        </property>
+      </activation>
+      <modules>
+        <module>integration-tests</module>
+      </modules>
+     </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
This includes python serverless workflow addon in regular modules, but keep Python IT module just for full build. 
This way community users will be able to test python examples at their own risk, without compromising release because of the inherent flaky nature of pip/jep relationship