### PR TITLE
Incubator-kie-issues-3871] Repeating timer gets executed immediately

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/timer/DateTimeUtils.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/timer/DateTimeUtils.java
@@ -20,6 +20,7 @@ package org.jbpm.process.core.timer;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -77,11 +78,28 @@ public class DateTimeUtils extends TimeUtils {
             result[2] = elements[2];
         } else {
             result[0] = elements[0].substring(1);
-            result[1] = OffsetDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+            result[1] = OffsetDateTime.now().plus(Duration.of(getMillis(elements[1]), ChronoUnit.MILLIS)).format(DateTimeFormatter.ISO_DATE_TIME);
             result[2] = elements[1];
         }
 
         return result;
+    }
+
+    public static long getMillis(String durationStr) {
+        if (durationStr.startsWith("PT")) { // ISO-8601 PTnHnMn.nS
+            return Duration.parse(durationStr).toMillis();
+        } else if (!durationStr.contains("T")) { // ISO-8601 PnYnMnWnD
+            Period period = Period.parse(durationStr);
+            OffsetDateTime now = OffsetDateTime.now();
+            return Duration.between(now, now.plus(period)).toMillis();
+        } else { // ISO-8601 PnYnMnWnDTnHnMn.nS
+            String[] elements = durationStr.split("T");
+            Period period = Period.parse(elements[0]);
+            Duration duration = Duration.parse("PT" + elements[1]);
+            OffsetDateTime now = OffsetDateTime.now();
+
+            return Duration.between(now, now.plus(period).plus(duration)).toMillis();
+        }
     }
 
     public static long[] parseRepeatableDateTime(String dateTimeStr) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/timer/DateTimeUtils.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/timer/DateTimeUtils.java
@@ -122,7 +122,7 @@ public class DateTimeUtils extends TimeUtils {
             } else if (DateTimeUtils.isPeriod(periodIn)) {
                 // If period is specified as duration then delay variable carry start time information
                 OffsetDateTime startTime = OffsetDateTime.parse(delayIn, DateTimeFormatter.ISO_DATE_TIME);
-                period = Duration.parse(periodIn);
+                period = Duration.of(getMillis(periodIn), ChronoUnit.MILLIS);
                 startAtDelayDur = Duration.between(OffsetDateTime.now(), startTime);
             } else {
                 // Both delay and period are specified as start and end times

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/timer/DateTimeUtilsTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/timer/DateTimeUtilsTest.java
@@ -18,9 +18,11 @@
  */
 package org.jbpm.process.core.timer;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import org.jbpm.test.util.AbstractBaseTest;
 import org.junit.jupiter.api.Test;
@@ -134,8 +136,72 @@ public class DateTimeUtilsTest extends AbstractBaseTest {
         long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
 
         assertThat(parsedRepeatable[0]).isEqualTo(-1L);
-        // Default delay time is 1000ms
-        assertThat(parsedRepeatable[1]).isLessThanOrEqualTo(MINUTE_IN_MILLISECONDS);
+        assertThat(parsedRepeatable[1] <= MINUTE_IN_MILLISECONDS).as("Parsed delay is bigger than " + MINUTE_IN_MILLISECONDS).isTrue();
+        assertThat(parsedRepeatable[1] > FIFTY_NINE_SECONDS_IN_MILLISECONDS)
+                .as("Parsed delay is too low! Expected value is between " + MINUTE_IN_MILLISECONDS + " and " + FIFTY_NINE_SECONDS_IN_MILLISECONDS + " but is " + parsedRepeatable[1]).isTrue();
         assertThat(parsedRepeatable[2]).as("Parsed period should be one minute in milliseconds but is " + parsedRepeatable[2]).isEqualTo(MINUTE_IN_MILLISECONDS);
+    }
+
+    @Test
+    public void testParseRepeatablePeriodPnYTnMOnly() {
+        OffsetDateTime now = OffsetDateTime.now();
+        long expectedMillis = Duration.between(now, now.plus(10, ChronoUnit.YEARS).plus(10, ChronoUnit.MINUTES)).toMillis();
+        String isoString = "R/P10YT10M";
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertThat(parsedRepeatable[0]).isEqualTo(-1L);
+        assertThat(parsedRepeatable[1] <= expectedMillis).as("Parsed delay is bigger than " + expectedMillis).isTrue();
+        assertThat(parsedRepeatable[1] > expectedMillis - 1000)
+                .as("Parsed delay is too low! Expected value is between " + expectedMillis + " and " + (expectedMillis - 1000) + " but is " + parsedRepeatable[1]).isTrue();
+        assertThat(parsedRepeatable[2]).as("Parsed period should be 10 years and 10 minutes in milliseconds but is " + parsedRepeatable[2]).isEqualTo(expectedMillis);
+    }
+
+    @Test
+    public void testParseRepeatablePeriodPTnHnMnOnly() {
+        OffsetDateTime now = OffsetDateTime.now();
+        long expectedMillis = Duration.between(now, now.plus(10, ChronoUnit.HOURS).plus(10, ChronoUnit.MINUTES).plus(10, ChronoUnit.SECONDS)).toMillis();
+        String isoString = "R/PT10H10M10S"; // ISO-8601 PTnHnMn.nS
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertThat(parsedRepeatable[0]).isEqualTo(-1L);
+        assertThat(parsedRepeatable[1] <= expectedMillis).as("Parsed delay is bigger than " + expectedMillis).isTrue();
+        assertThat(parsedRepeatable[1] > expectedMillis - 1000)
+                .as("Parsed delay is too low! Expected value is between " + expectedMillis + " and " + (expectedMillis - 1000) + " but is " + parsedRepeatable[1]).isTrue();
+        assertThat(parsedRepeatable[2]).as("Parsed period should be 10 hours, 10 minutes and 10 seconds in milliseconds but is " + parsedRepeatable[2]).isEqualTo(expectedMillis);
+    }
+
+    @Test
+    public void testParseRepeatablePeriodPnYnMnWnDOnly() {
+        OffsetDateTime now = OffsetDateTime.now();
+        long expectedMillis = Duration
+                .between(now, now.plus(10, ChronoUnit.YEARS).plus(10, ChronoUnit.MONTHS).plus(10, ChronoUnit.WEEKS).plus(10, ChronoUnit.DAYS)).toMillis();
+        String isoString = "R/P10Y10M10W10D"; // ISO-8601 PnYnMnWnD
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertThat(parsedRepeatable[0]).isEqualTo(-1L);
+        assertThat(parsedRepeatable[1] <= expectedMillis).as("Parsed delay is bigger than " + expectedMillis).isTrue();
+        assertThat(parsedRepeatable[1] > expectedMillis - 1000)
+                .as("Parsed delay is too low! Expected value is between " + expectedMillis + " and " + (expectedMillis - 1000) + " but is " + parsedRepeatable[1]).isTrue();
+        assertThat(parsedRepeatable[2]).as("Parsed period should be 10 years, 10 months, 10 weeks and 10 days in milliseconds but is " + parsedRepeatable[2]).isEqualTo(expectedMillis);
+    }
+
+    @Test
+    public void testParseRepeatablePeriodPnYnMnWnDTnHnMnOnly() {
+        OffsetDateTime now = OffsetDateTime.now();
+        long expectedMillis = Duration.between(now, now.plus(10, ChronoUnit.YEARS).plus(10, ChronoUnit.MONTHS).plus(10, ChronoUnit.WEEKS)
+                .plus(10, ChronoUnit.DAYS).plus(10, ChronoUnit.HOURS).plus(10, ChronoUnit.MINUTES).plus(10, ChronoUnit.SECONDS)).toMillis();
+        String isoString = "R/P10Y10M10W10DT10H10M10S"; // ISO-8601 PnYnMnWnDTnHnMn.nS
+
+        long[] parsedRepeatable = DateTimeUtils.parseRepeatableDateTime(isoString);
+
+        assertThat(parsedRepeatable[0]).isEqualTo(-1L);
+        assertThat(parsedRepeatable[1] <= expectedMillis).as("Parsed delay is bigger than " + expectedMillis).isTrue();
+        assertThat(parsedRepeatable[1] > expectedMillis - 1000)
+                .as("Parsed delay is too low! Expected value is between " + expectedMillis + " and " + (expectedMillis - 1000) + " but is " + parsedRepeatable[1]).isTrue();
+        assertThat(parsedRepeatable[2]).as("Parsed period should be 10 years, 10 months, 10 weeks, 10 days, 10 hours, 10 minutes and 10 seconds in milliseconds but is " + parsedRepeatable[2])
+                .isEqualTo(expectedMillis);
     }
 }

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/timer/DateTimeUtilsTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/timer/DateTimeUtilsTest.java
@@ -135,7 +135,7 @@ public class DateTimeUtilsTest extends AbstractBaseTest {
 
         assertThat(parsedRepeatable[0]).isEqualTo(-1L);
         // Default delay time is 1000ms
-        assertThat(parsedRepeatable[1]).isEqualTo(1000L);
+        assertThat(parsedRepeatable[1]).isLessThanOrEqualTo(MINUTE_IN_MILLISECONDS);
         assertThat(parsedRepeatable[2]).as("Parsed period should be one minute in milliseconds but is " + parsedRepeatable[2]).isEqualTo(MINUTE_IN_MILLISECONDS);
     }
 }


### PR DESCRIPTION


<!-- Please don't forget your Issue link -->
https://github.com/apache/incubator-kie-kogito-runtimes/issues/3871

<!-- Please provide a short description of what this PR does -->
Using timer node with timer expression R/PT5M, the job gets executed immediately, then in the configured 5min intervals.

