### PR TITLE
[Incubator-kie-issues#1913] Ability to dynamically run a Decision based on process variables

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.jbpm.compiler.xml.Parser;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.DataAssociation;
+import org.jbpm.workflow.core.impl.DataDefinition;
 import org.jbpm.workflow.core.node.Assignment;
 import org.jbpm.workflow.core.node.RuleSetNode;
 import org.jbpm.workflow.instance.rule.RuleType;
@@ -66,7 +67,12 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
             Map<String, String> parameters = new HashMap<>();
             for (DataAssociation dataAssociation : ruleSetNode.getIoSpecification().getDataInputAssociation()) {
                 for (Assignment assignment : dataAssociation.getAssignments()) {
-                    parameters.put(assignment.getTo().getLabel(), assignment.getFrom().getExpression());
+                    DataDefinition fromDefinition = assignment.getFrom();
+                    String fromValue  = fromDefinition.getExpression();
+                    if(!fromDefinition.hasExpression()) {
+                        fromValue = String.format("#{%s}", fromDefinition.getId());
+                    }
+                    parameters.put(assignment.getTo().getLabel(), fromValue);
                 }
             }
 


### PR DESCRIPTION
The goal of this JIRA is to support the #{var_name} syntax in the Business Rules task handler for both DRL and DMN execution.
During process instance execution, the defined process variables need to be set. When the Business Rules task handler is executed, it will find and execute the correct rule or decision based on the variable content.

The variable is resolved within DecisionRuleTypeEngineImpl.java

![image](https://github.com/user-attachments/assets/641aa04f-d14f-4267-8c2f-b04bde6aa5a5)


What I understood is if we get #var format in (inputModel), it can resolve exact value of that variable.

In BusinessRuleTaskHandler when we assign a value we have to check if it has an expression or not "if(!fromDefinition.hasExpression())" If it doesn't have expression it will be variable. So kept value as variable format, then its going to be be resolved at evaluate method within DecisionRuleTypeEngineImpl.java.



Tested the above implementation with testDMNBusinessRuleTask ith in ActivityTest.class 
Changed the ![CDATA[0020-vacation-days]]> in the bpmn file to <![CDATA[#{modelName}]]> and tested.

Closes: https://github.com/apache/incubator-kie-issues/issues/1913

