### PR TITLE
[Incubator-kie-issues-1932] Fix for node name being null for throw and catch link

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
@@ -74,7 +74,7 @@ public abstract class AbstractVisitor {
     }
 
     protected String getOrDefault(String value, String defaultValue) {
-        if (value == null) {
+        if (value == null || value.trim().isEmpty()) {
             return sanitizeString(defaultValue);
         }
         return sanitizeString(value);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/CatchLinkNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/CatchLinkNodeVisitor.java
@@ -45,6 +45,7 @@ public class CatchLinkNodeVisitor extends AbstractNodeVisitor<CatchLinkNode> {
         body.addStatement(getAssignedFactoryMethod(factoryField, CatchLinkNodeFactory.class, nodeId,
                 getNodeKey(), getWorkflowElementConstructor(node.getId())));
         body.addStatement(getDoneMethod(nodeId));
+        body.addStatement(getNameMethod(node, "CatchLink"));
     }
 
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ThrowLinkNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ThrowLinkNodeVisitor.java
@@ -45,6 +45,7 @@ public class ThrowLinkNodeVisitor extends AbstractNodeVisitor<ThrowLinkNode> {
         body.addStatement(getAssignedFactoryMethod(factoryField, ThrowLinkNodeFactory.class, nodeId,
                 getNodeKey(), getWorkflowElementConstructor(node.getId())));
         body.addStatement(getDoneMethod(nodeId));
+        body.addStatement(getNameMethod(node, "ThrowLink"));
     }
 
 }

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -204,7 +204,7 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
 
     private static final BiConsumer<Node, Node> nodeAsserter = (expected, current) -> {
         assertThat(current.getId()).isEqualTo(expected.getId());
-        if (expected.getName() != null) {
+        if (expected.getName() != null && !expected.getName().trim().isEmpty()) {
             assertThat(current.getName()).isEqualTo(expected.getName());
         } else {
             assertThat(current.getName()).as(current.getClass().getName()).isNotNull();

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -38,6 +38,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.drools.io.FileSystemResource;
 import org.jbpm.process.core.timer.Timer;
@@ -204,7 +205,7 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
 
     private static final BiConsumer<Node, Node> nodeAsserter = (expected, current) -> {
         assertThat(current.getId()).isEqualTo(expected.getId());
-        if (expected.getName() != null && !expected.getName().trim().isEmpty()) {
+        if (!StringUtils.isBlank(expected.getName())) {
             assertThat(current.getName()).isEqualTo(expected.getName());
         } else {
             assertThat(current.getName()).as(current.getClass().getName()).isNotNull();


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1932

Added default name for ThrowLink and CatchLink nodes

<img width="1314" alt="Screenshot 2025-04-25 at 9 20 44 PM" src="https://github.com/user-attachments/assets/f910437d-9197-4c3a-8f00-f9d9ff78860b" />
