### PR TITLE
[incubator-kie-issues-1924] Data Audit stores subprocess events always in completed state

### DIFF
--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/adapter/AbstractDataEventAdapter.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/adapter/AbstractDataEventAdapter.java
@@ -30,6 +30,7 @@ import org.kie.kogito.event.process.ProcessInstanceNodeEventBody;
 import org.kie.kogito.event.process.ProcessInstanceStateDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceStateEventBody;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcessInstance;
 import org.kie.kogito.internal.process.workitem.KogitoWorkItem;
@@ -80,9 +81,15 @@ public abstract class AbstractDataEventAdapter implements DataEventAdapter {
                 .parentInstanceId(pi.getParentProcessInstanceId())
                 .rootProcessId(pi.getRootProcessId())
                 .rootProcessInstanceId(pi.getRootProcessInstanceId())
-                .state(event.getProcessInstance().getState())
                 .businessKey(pi.getBusinessKey())
                 .slaDueDate(pi.getSlaDueDate());
+
+        // this is due to the listener order execution. we cannot trust the state of the process if it start and finishes at the same time.
+        if (eventType == ProcessInstanceStateEventBody.EVENT_TYPE_STARTED) {
+            builder.state(KogitoProcessInstance.STATE_ACTIVE);
+        } else {
+            builder.state(event.getProcessInstance().getState());
+        }
 
         String securityRoles = (String) event.getProcessInstance().getProcess().getMetaData().get("securityRoles");
         if (securityRoles != null) {

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -1667,6 +1667,17 @@
         <classifier>sources</classifier>
       </dependency>
       <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kogito-addons-quarkus-jobs</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.kie</groupId>
+          <artifactId>kogito-addons-quarkus-jobs</artifactId>
+          <version>${project.version}</version>
+          <classifier>sources</classifier>
+      </dependency>
+      <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-jobs-service-embedded</artifactId>
         <version>${project.version}</version>

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/rules/PublishEventBusinessRuleIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/rules/PublishEventBusinessRuleIT.java
@@ -86,9 +86,9 @@ public class PublishEventBusinessRuleIT extends AbstractRulesCodegenIT {
 
         assertThat(processInstanceStateEvents).hasSize(2);
         assertThat(processInstanceStateEvents)
-            .extracting(ProcessInstanceStateDataEvent::getData)
-            .extracting(ProcessInstanceStateEventBody::getState)
-            .containsExactlyInAnyOrder(KogitoProcessInstance.STATE_ACTIVE, KogitoProcessInstance.STATE_COMPLETED);
+                .extracting(ProcessInstanceStateDataEvent::getData)
+                .extracting(ProcessInstanceStateEventBody::getState)
+                .containsExactlyInAnyOrder(KogitoProcessInstance.STATE_ACTIVE, KogitoProcessInstance.STATE_COMPLETED);
 
         ProcessInstanceStateDataEvent processDataEvent =
                 processInstanceStateEvents.stream().filter(e -> e.getData().getState() == KogitoProcessInstance.STATE_COMPLETED).findFirst().orElseThrow();


### PR DESCRIPTION
Issue: https://github.com/apache/incubator-kie-issues/issues/1937