### PR TITLE
[NO_ISSUE] Add toString method to CronTrigger and SimpleTimerTrigger

### DIFF
--- a/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/CronTrigger.java
+++ b/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/CronTrigger.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.timer.impl;
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -368,5 +369,11 @@ public class CronTrigger
                 this.nextFireTime = getTimeAfter(this.nextFireTime);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return "CronTrigger [startTime=" + startTime + ", endTime=" + endTime + ", repeatLimit=" + repeatLimit + ", repeatCount=" + repeatCount + ", nextFireTime="
+                + nextFireTime + ", cronEx=" + cronEx + ", calendarNames=" + Arrays.toString(calendarNames) + ", calendars=" + calendars + "]";
     }
 }

--- a/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/SimpleTimerTrigger.java
+++ b/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/SimpleTimerTrigger.java
@@ -286,4 +286,9 @@ public class SimpleTimerTrigger implements Trigger {
     private long getPeriodInMillis() {
         return periodUnit.getDuration().multipliedBy(period).toMillis();
     }
+
+    @Override
+    public String toString() {
+        return "SimpleTimerTrigger [startTime=" + startTime + ", period=" + period + ", periodUnit=" + periodUnit + ", repeatCount=" + repeatCount + ", endTime=" + endTime + "]";
+    }
 }


### PR DESCRIPTION
Adding toString methods to make the log output clearer, eg:
```
TRACE [org.kie.kogito.jobs.service.job.DelegateJob:56] (VertxTimerServiceScheduler-1) Executing job for context: JobDetails[id='4815d4cd-c7b1-4e0d-85fb-fb738bba48a2', [...] trigger=SimpleTimerTrigger[startTime=Tue Apr 29 21:48:33 UTC 2025, period=0, periodUnit=Millis, repeatCount=0, endTime=null], executionTimeout=null, executionTimeoutUnit=null, created=2025-04-29T21:48:15.289Z[UTC]]
```

