### PR TITLE
[CVE-2020-15250 unit-4.12.jar] Version update

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -169,6 +169,13 @@
       </dependency>
 
       <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
         <version>${version.org.bouncycastle.bc.jdk18on}</version>


### PR DESCRIPTION

1. Identification
Ran:
`mvn dependency:tree`
Identified:
`junit:junit:jar:4.12:test`
being pulled transitively from:
`quarkus-test-kubernetes-client`

2. FIX:
added dependency in kogito-build/kogito-dependencies-bom/pom.xml


```
<dependency>
  <groupId>junit</groupId>
  <artifactId>junit</artifactId>
  <version>4.13.2</version>
  <scope>test</scope>
</dependency> 
```


3. Confirmed fix after compilation 


```
mvn dependency:tree `
>>   "-Dincludes=junit:junit" `
>>   "-DoutputFile=$(pwd)\mvn_dependency_tree_junit_junit.txt" `
>>   -DappendOutput=true `
>>   -Dverbose
```


output:

```
+- io.quarkus:quarkus-test-kubernetes-client:jar:3.15.3:test
| \- io.fabric8:kubernetes-server-mock:jar:6.13.4:test (version managed from 6.13.4)
| \- io.fabric8:mockwebserver:jar:6.13.4:test (version managed from 6.13.4)
| \- com.squareup.okhttp3:mockwebserver:jar:3.12.12:test
| \- (junit:junit:jar:4.13.2:test - version managed from 4.12; scope managed from compile; omitted for duplicate)
```

Tested the same in kogito-runtimes and examples.




