### PR TITLE
[incubator-kie-issues-1965] Support re-scheduling SLAs and scheduled Jobs

### DIFF
--- a/addons/common/process-management/src/main/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResource.java
+++ b/addons/common/process-management/src/main/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResource.java
@@ -32,6 +32,8 @@ import org.jbpm.workflow.core.WorkflowProcess;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
+import org.kie.kogito.jobs.JobDescription;
+import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessError;
 import org.kie.kogito.process.ProcessInstance;
@@ -50,6 +52,9 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
     private static final String PROCESS_NOT_FOUND = "Process with id %s not found";
     private static final String PROCESS_INSTANCE_NOT_FOUND = "Process instance with id %s not found";
     private static final String PROCESS_INSTANCE_NOT_IN_ERROR = "Process instance with id %s is not in error state";
+
+    // How to get jobService bean
+    private JobsService jobsService;
 
     private Supplier<Processes> processes;
 
@@ -307,4 +312,22 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
     protected abstract T badRequestResponse(String message);
 
     protected abstract T notFoundResponse(String message);
+
+    public T doUpdateNodeInstanceSla(String processId, String processInstanceId, String nodeInstanceId, SlaPayload sla) {
+        return executeOnProcessInstance(processId, processInstanceId, processInstance -> {
+            // Update Node SLA
+            processInstance.updateNodeSla(nodeInstanceId, sla);
+            // Update job expiration
+            jobsService.rescheduleJob(job);
+
+        });
+    }
+
+    public T doUpdateProcessInstanceSla(String processId, String processInstanceId, SlaPayload sla) {
+        return executeOnProcessInstance(processId, processInstanceId, processInstance -> {
+            // Update Process SLA
+            // Update job expiration
+            return null;
+        });
+    }
 }

--- a/addons/common/process-management/src/main/java/org/kie/kogito/process/management/ProcessInstanceManagement.java
+++ b/addons/common/process-management/src/main/java/org/kie/kogito/process/management/ProcessInstanceManagement.java
@@ -46,4 +46,8 @@ public interface ProcessInstanceManagement<T> {
 
     T migrateInstance(String processId, String processInstanceId, ProcessMigrationSpec migrationSpec);
 
+    T updateNodeInstanceSla(String processId, String processInstanceId, String nodeInstanceId, SlaPayload SLAPayload);
+
+    T updateProcessInstanceSla(String processId, String processInstanceId, SlaPayload SLAPayload);
+
 }

--- a/addons/common/process-management/src/main/java/org/kie/kogito/process/management/SlaPayload.java
+++ b/addons/common/process-management/src/main/java/org/kie/kogito/process/management/SlaPayload.java
@@ -1,0 +1,19 @@
+package org.kie.kogito.process.management;
+
+import org.kie.kogito.jobs.ExpirationTime;
+
+public class SlaPayload {
+    ExpirationTime expirationTime;
+
+    public SlaPayload(ExpirationTime expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    public ExpirationTime getExpirationTime() {
+        return expirationTime;
+    }
+
+    public void setExpirationTime(ExpirationTime expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/JobsService.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/JobsService.java
@@ -42,4 +42,6 @@ public interface JobsService {
      * @return returns true if the cancellation was successful, otherwise false
      */
     boolean cancelJob(String id);
+
+    String rescheduleJob(JobDescription description);
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -266,6 +266,7 @@ public interface ProcessInstance<T> {
     void cancelNodeInstance(String nodeInstanceId);
 
     void retriggerNodeInstance(String nodeInstanceId);
+    void updateNodeSla(String nodeInstanceId, SlaPayload sla);
 
     Set<EventDescription<?>> events();
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -513,6 +513,23 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         });
     }
 
+    @Override
+    public void updateNodeSla(String nodeInstanceId, SlaPayload sla) {
+        processInstanceLockStrategy.executeOperation(id, () -> {
+            NodeInstance nodeInstance = processInstance()
+                    .getNodeInstances(true)
+                    .stream()
+                    .filter(ni -> ni.getStringId().equals(nodeInstanceId))
+                    .findFirst()
+                    .orElseThrow(() -> new NodeInstanceNotFoundException(this.id, nodeInstanceId));
+
+            //Set node sla
+            //nodeInstance.setsla()
+            removeOnFinish();
+            return null;
+        });
+    }
+
     protected WorkflowProcessInstance processInstance() {
         if (this.processInstance == null) {
             reloadSupplier.accept(this);

--- a/quarkus/addons/process-management/runtime/src/main/java/org/kie/kogito/process/management/ProcessInstanceManagementResource.java
+++ b/quarkus/addons/process-management/runtime/src/main/java/org/kie/kogito/process/management/ProcessInstanceManagementResource.java
@@ -173,4 +173,21 @@ public class ProcessInstanceManagementResource extends BaseProcessInstanceManage
     public Response cancelProcessInstanceId(@PathParam("processId") String processId, @PathParam("processInstanceId") String processInstanceId) {
         return doCancelProcessInstanceId(processId, processInstanceId);
     }
+
+    @Override
+    @GET
+    @Path("{processId}/instances/{processInstanceId}/nodeInstances/{nodeInstanceId}/sla")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateNodeInstanceSla(@PathParam("processId") String processId, @PathParam("processInstanceId") String processInstanceId, @PathParam("nodeInstanceId") String nodeInstanceId, SlaPayload slaPayload) {
+        return doUpdateNodeInstanceSla(processId, processInstanceId, nodeInstanceId, slaPayload);
+    }
+
+    @Override
+    @GET
+    @Path("{processId}/instances/{processInstanceId}/sla")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateProcessInstanceSla(@PathParam("processId") String processId, @PathParam("processInstanceId") String processInstanceId, SlaPayload slaPayload) {
+        return doUpdateProcessInstanceSla(processId, processInstanceId, slaPayload);
+    }
+
 }

--- a/springboot/addons/jobs/src/main/java/org/kie/kogito/jobs/management/springboot/SpringRestJobsService.java
+++ b/springboot/addons/jobs/src/main/java/org/kie/kogito/jobs/management/springboot/SpringRestJobsService.java
@@ -99,12 +99,29 @@ public class SpringRestJobsService extends RestJobsService {
         }
     }
 
+    @Override
+    public String rescheduleJob(JobDescription description) {
+        return restTemplate.patchForObject(getJobsServiceUri(), buildJobRequest(description), String.class);
+    }
+
     private HttpEntity<String> buildJobRequest(Job job) {
         String json;
         try {
             json = objectMapper.writeValueAsString(job);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("It was not possible to create the http request for the job: " + job, e);
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(json, headers);
+    }
+
+    private HttpEntity<String> buildJobRequest(JobDescription description) {
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(description);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("It was not possible to create the http request for the job: " + description, e);
         }
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);


### PR DESCRIPTION
For a process that contains SLAs either at the process or the node levels, the engine creates timers. Through the management console / the graphql mutations, users can reschedule those timers:

![image](https://github.com/user-attachments/assets/79ad008c-4b2a-464a-a0f9-acb7135843e1)

However, the SLA set for the process/node is not updated accordingly:

![image](https://github.com/user-attachments/assets/603fb3be-e3cd-45a3-903e-78491e049468)

Rescheduling SLA timers should cause an update of the SLA of the process/node.