### PR TITLE
Issue-3925 Extended Knative custom functions to support headers and query params

### DIFF
--- a/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/PlainJsonKnativeParamsDecorator.java
+++ b/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/PlainJsonKnativeParamsDecorator.java
@@ -23,20 +23,21 @@ import java.util.Map;
 
 import org.kie.kogito.event.cloudevents.utils.CloudEventUtils;
 import org.kie.kogito.internal.process.workitem.KogitoWorkItem;
-import org.kogito.workitem.rest.decorators.ParamsDecorator;
+import org.kogito.workitem.rest.decorators.PrefixParamsDecorator;
 
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 
 import static org.kie.kogito.addons.quarkus.knative.serving.customfunctions.KnativeWorkItemHandler.CLOUDEVENT_SENT_AS_PLAIN_JSON_ERROR_MESSAGE;
 import static org.kie.kogito.addons.quarkus.knative.serving.customfunctions.KnativeWorkItemHandler.ID;
 
-public final class PlainJsonKnativeParamsDecorator implements ParamsDecorator {
+public final class PlainJsonKnativeParamsDecorator extends PrefixParamsDecorator {
 
     @Override
     public void decorate(KogitoWorkItem workItem, Map<String, Object> parameters, HttpRequest<?> request) {
         if (isCloudEvent(KnativeFunctionPayloadSupplier.getPayload(parameters))) {
             throw new IllegalArgumentException(CLOUDEVENT_SENT_AS_PLAIN_JSON_ERROR_MESSAGE);
         }
+        super.decorate(workItem, parameters, request);
     }
 
     private static boolean isCloudEvent(Map<String, Object> payload) {


### PR DESCRIPTION
Added header support for Knative custom functions, as requested in the feature proposal #3925.
Moreover, since the extension was based on the REST custom function's `PrefixParamsDecorator`, it also adds support for using query params.
The usage is similar to the REST custom function:

```json
{
 "functionRef": {
   "refName": "knativeService",
   "arguments": {
     "category": "electronics",
     "QUERY_sort": "asc",
     "HEADER_customheader": "value"
   }
 }
}
```