### PR TITLE
[kie-issues#1967] Update wiremock and swagger parser dependency

### DIFF
--- a/addons/common/kubernetes/pom.xml
+++ b/addons/common/kubernetes/pom.xml
@@ -77,8 +77,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -59,7 +59,7 @@
     <version.com.github.javaparser>3.26.1</version.com.github.javaparser>
     <version.com.fasterxml.jackson.datatype>2.17.2</version.com.fasterxml.jackson.datatype>
     <version.com.github.victools>4.31.0</version.com.github.victools>
-    <version.com.github.tomakehurst.wiremock>2.35.2</version.com.github.tomakehurst.wiremock>
+    <version.com.github.tomakehurst.wiremock>3.13.0</version.com.github.tomakehurst.wiremock>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
     <!-- We don't use gson directly. This is just to align versions of transitive dependencies -->
     <version.com.google.gson>2.10.1</version.com.google.gson>
@@ -97,7 +97,7 @@
 
     <version.io.quarkus.camel>3.15.1</version.io.quarkus.camel> <!-- TODO: quarkus version mismatch -->
 
-    <version.io.swagger.parser.v3>2.1.19</version.io.swagger.parser.v3>
+    <version.io.swagger.parser.v3>2.1.20</version.io.swagger.parser.v3>
     <version.io.swagger.core.v3>2.2.19</version.io.swagger.core.v3>
 
     <version.org.apache.commons>3.14.0</version.org.apache.commons>
@@ -592,14 +592,14 @@
       </dependency>
 
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock</artifactId>
         <version>${version.com.github.tomakehurst.wiremock}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8-standalone</artifactId>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock-standalone</artifactId>
         <version>${version.com.github.tomakehurst.wiremock}</version>
         <scope>test</scope>
       </dependency>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
@@ -57,8 +57,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
@@ -73,8 +73,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
@@ -86,8 +86,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/addons/knative/serving/integration-tests/pom.xml
+++ b/quarkus/addons/knative/serving/integration-tests/pom.xml
@@ -102,8 +102,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/addons/knative/serving/runtime/pom.xml
+++ b/quarkus/addons/knative/serving/runtime/pom.xml
@@ -74,8 +74,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/addons/kubernetes/runtime/pom.xml
+++ b/quarkus/addons/kubernetes/runtime/pom.xml
@@ -71,8 +71,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/addons/microprofile-config-service-catalog/integration-tests/pom.xml
+++ b/quarkus/addons/microprofile-config-service-catalog/integration-tests/pom.xml
@@ -88,8 +88,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/pom.xml
@@ -97,8 +97,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/src/test/java/org/kie/kogito/quarkus/serverless/workflow/deployment/livereload/LiveReloadProcessorTest.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/src/test/java/org/kie/kogito/quarkus/serverless/workflow/deployment/livereload/LiveReloadProcessorTest.java
@@ -76,7 +76,7 @@ public class LiveReloadProcessorTest {
     }
 
     private static void configureWiremockServer() {
-        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().extensions(new ResponseTemplateTransformer(false)).dynamicPort());
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().extensions(new ResponseTemplateTransformer(null, false, null, java.util.Collections.emptyList())).dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(post(urlEqualTo("/echo"))

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -119,8 +119,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EnumEchoServiceMock.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EnumEchoServiceMock.java
@@ -41,7 +41,7 @@ public class EnumEchoServiceMock implements QuarkusTestResourceLifecycleManager 
     }
 
     private void configureWiremockServer() {
-        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().extensions(new ResponseTemplateTransformer(false)).dynamicPort());
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().extensions(new ResponseTemplateTransformer(null, false, null, java.util.Collections.emptyList())).dynamicPort());
         wireMockServer.start();
 
         wireMockServer.stubFor(post(urlEqualTo("/echo"))

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
@@ -100,8 +100,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
@@ -81,8 +81,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -129,8 +129,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
@@ -112,8 +112,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Updates wiremock and other dependencies to upgrade commons-io library that is transitively brought by these libraries. Replacement PR for https://github.com/apache/incubator-kie-kogito-runtimes/pull/3924 to make PR checks run together with related PR in kogito-examples (TODO - add link when opened).  