### PR TITLE
[NO-ISSUE] Disable keycloak dev services in Sonataflow integration tests.

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/src/main/resources/application.properties
@@ -18,3 +18,4 @@
 #
 
 quarkus.smallrye-openapi.management.enabled=true
+quarkus.keycloak.devservices.enabled=false

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
@@ -36,6 +36,7 @@ kogito.codegen.ignoreHiddenFiles=false
 
 quarkus.kafka.devservices.enabled=false
 quarkus.kubernetes-client.devservices.enabled=false
+quarkus.keycloak.devservices.enabled=false
 
 # OpenApi client properties, see OperationsMockService, which is mocking these two services
 quarkus.rest-client."multiplication.cluster1".url=${multiplication-service-mock.url}


### PR DESCRIPTION
This disables keycloak dev services in sonataflow integration tests. 