### PR TITLE
[NO_ISSUE] Return complete workItem for trigger REST endpoints

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceWorkItemQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceWorkItemQuarkusTemplate.java
@@ -49,7 +49,7 @@ public class $Type$Resource {
         return processService.signalWorkItem(process, id, "$taskName$", SecurityPolicy.of(identityProviderFactory.getOrImpersonateIdentity(user, groups)))
                 .map(task -> Response
                         .created(uriInfo.getAbsolutePathBuilder().path(task.getId()).build())
-                        .entity(task.getResults())
+                        .entity(task)
                         .build())
                 .orElseThrow(NotFoundException::new);
     }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceWorkItemSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceWorkItemSpringTemplate.java
@@ -56,7 +56,7 @@ public class $Type$Resource {
                         .created(uriComponentsBuilder
                                 .path("/$name$/{id}/$taskName$/{taskId}")
                                 .buildAndExpand(id, task.getId()).toUri())
-                        .body(task.getResults()))
+                        .body(task))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 


### PR DESCRIPTION
A small improvement to make it easier to work with the `trigger` endpoint. This call:
```
curl -X 'POST' \
  'http://localhost:8080/serviceDesk/23bb6bff-989b-4639-80ab-5f8d51c68803/ReceiveSupportComment/trigger?group=support' \
  -H 'accept: */*' \
  -d ''
```
currently returns an empty body - `task.getResults()`.

With the proposed change, it returns the full workItem object, eg:
```
{
  "id": "41751bb2-11e3-48d9-ac1d-ee906bbde69c",
  "nodeInstanceId": "53aee026-ae3b-4da0-adcb-40d71be424ec",
  "nodeId": {},
  "name": "ReceiveSupportComment",
  "state": 1,
  "phase": "activate",
  "phaseStatus": "Activated",
  "parameters": {
    "TaskName": "ReceiveSupportComment",
    "Skippable": "false",
    "GroupId": "support",
    "NodeName": "Receive support comment",
    "UNIQUE_TASK_ID": "_C5983E55-DC49-4839-AC3E-3E8344A29262",
    "supportCase": {
      "product": {
        "name": "Kogito",
        "family": "Middleware"
      },
      "description": "Kogito is not working for some reason.",
      "engineer": "kelly",
      "customer": "Paco the customer",
      "state": "WAITING_FOR_OWNER",
      "comments": null,
      "questionnaire": null
    },
    "supportGroup": "Kogito"
  },
  "results": {},
  "workItemHandlerName": "Human Task",
  "externalReferenceId": "efe5c719-40ae-40bf-a1ef-c36e2f3e8e40"
}
```