### PR TITLE
[incubator-kie-issues#2006] Data Index: `NodeInstance` keeps `retrigger` set to false after being retriggered.

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -489,17 +489,15 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
         if (remove) {
             cancel();
         }
-        isRetrigger = true;
-        triggerNode(getNodeId(), !remove);
+        retriggerNode(nodeId, !remove);
     }
 
-    public void triggerNode(WorkflowElementIdentifier nodeId) {
-        triggerNode(nodeId, true);
-    }
-
-    public void triggerNode(WorkflowElementIdentifier nodeId, boolean fireEvents) {
-        org.jbpm.workflow.instance.NodeInstance nodeInstance = ((org.jbpm.workflow.instance.NodeInstanceContainer) getNodeInstanceContainer())
+    private void retriggerNode(WorkflowElementIdentifier nodeId, boolean fireEvents) {
+        NodeInstanceImpl nodeInstance = (NodeInstanceImpl) ((org.jbpm.workflow.instance.NodeInstanceContainer) getNodeInstanceContainer())
                 .getNodeInstance(((KogitoNode) getNode()).getParentContainer().getNode(nodeId));
+
+        nodeInstance.internalSetRetrigger(true);
+
         triggerNodeInstance(nodeInstance, Node.CONNECTION_DEFAULT_TYPE, fireEvents);
     }
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2006

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

Many thanks for submitting your Pull Request :heart:! 

<!-- Please don't forget your Issue link -->
Closes/Fixes/Resolves #ISSUE-NUMBER

<!-- Please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/apache/incubator-kie-kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


