### PR TITLE
[Fix #3971] Adding default event broker and support for context attrs

### DIFF
--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/DataEventFactory.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/DataEventFactory.java
@@ -68,7 +68,9 @@ public class DataEventFactory {
 
     public static <T> DataEvent<T> from(T eventData, String trigger, KogitoProcessInstance pi, Map<String, Object> contextAttributes) {
         AbstractDataEvent<T> ce = (AbstractDataEvent<T>) from(eventData, trigger, URI.create("/process/" + pi.getProcessId()), Optional.empty(), ProcessMeta.fromKogitoProcessInstance(pi));
-        contextAttributes.forEach((k, v) -> ce.addExtensionAttribute(k, v));
+        if (contextAttributes != null) {
+            contextAttributes.forEach((k, v) -> ce.addExtensionAttribute(k, v));
+        }
         return ce;
     }
 

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/DataEventFactory.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/DataEventFactory.java
@@ -21,6 +21,8 @@ package org.kie.kogito.event;
 import java.io.IOException;
 import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -61,7 +63,13 @@ public class DataEventFactory {
     }
 
     public static <T> DataEvent<T> from(T eventData, String trigger, KogitoProcessInstance pi) {
-        return from(eventData, trigger, URI.create("/process/" + pi.getProcessId()), Optional.empty(), ProcessMeta.fromKogitoProcessInstance(pi));
+        return from(eventData, trigger, pi, Collections.emptyMap());
+    }
+
+    public static <T> DataEvent<T> from(T eventData, String trigger, KogitoProcessInstance pi, Map<String, Object> contextAttributes) {
+        AbstractDataEvent<T> ce = (AbstractDataEvent<T>) from(eventData, trigger, URI.create("/process/" + pi.getProcessId()), Optional.empty(), ProcessMeta.fromKogitoProcessInstance(pi));
+        contextAttributes.forEach((k, v) -> ce.addExtensionAttribute(k, v));
+        return ce;
     }
 
     public static <T> DataEvent<T> from(T eventData, String type, URI source, Optional<String> subject, CloudEventExtension... extensions) {
@@ -82,5 +90,4 @@ public class DataEventFactory {
 
     private DataEventFactory() {
     }
-
 }

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/AbstractMessageProducer.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/AbstractMessageProducer.java
@@ -18,13 +18,15 @@
  */
 package org.kie.kogito.event.impl;
 
+import java.util.Map;
+
 import org.kie.kogito.event.DataEventFactory;
 import org.kie.kogito.event.EventEmitter;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AbstractMessageProducer<D> implements MessageProducer<D> {
+public abstract class AbstractMessageProducer<D> implements MessageProducerWithContext<D> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractMessageProducer.class);
 
@@ -48,8 +50,8 @@ public abstract class AbstractMessageProducer<D> implements MessageProducer<D> {
     }
 
     @Override
-    public void produce(KogitoProcessInstance pi, D eventData) {
-        emitter.emit(DataEventFactory.from(eventData, trigger, pi))
+    public void produce(KogitoProcessInstance pi, D eventData, Map<String, Object> contextAttrs) {
+        emitter.emit(DataEventFactory.from(eventData, trigger, pi, contextAttrs))
                 .exceptionally(ex -> {
                     logger.error("An error was caught while process " + pi.getProcessId() + " produced message " + eventData, ex);
                     return null;

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/MessageProducerWithContext.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/MessageProducerWithContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.event.impl;
+
+import java.util.Map;
+
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
+
+public interface MessageProducerWithContext<D> extends MessageProducer<D> {
+
+    default void produce(KogitoProcessInstance pi, D eventData) {
+        produce(pi, eventData, Map.of());
+    }
+
+    void produce(KogitoProcessInstance pi, D eventData, Map<String, Object> contextAttrs);
+}

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ExpressionUtils.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ExpressionUtils.java
@@ -141,10 +141,12 @@ public class ExpressionUtils {
         }
         if (objectClass != null) {
             // will generate TypeConverterRegistry.get().forType("JsonNode.class").apply("{\"dog\":\"perro\"}"))
-            return new CastExpr(StaticJavaParser.parseClassOrInterfaceType(object.getClass().getName()),
-                    new MethodCallExpr(new MethodCallExpr(new MethodCallExpr(new TypeExpr(StaticJavaParser.parseClassOrInterfaceType(TypeConverterRegistry.class.getName())), "get"), "forType",
-                            NodeList.nodeList(new StringLiteralExpr(objectClass.getName()))), "apply",
-                            NodeList.nodeList(new StringLiteralExpr().setString(TypeConverterRegistry.get().forTypeReverse(object).apply((object))))));
+            String str = TypeConverterRegistry.get().forTypeReverse(object).apply(object);
+            return str == null ? new NullLiteralExpr()
+                    : new CastExpr(StaticJavaParser.parseClassOrInterfaceType(object.getClass().getName()),
+                            new MethodCallExpr(new MethodCallExpr(new MethodCallExpr(new TypeExpr(StaticJavaParser.parseClassOrInterfaceType(TypeConverterRegistry.class.getName())), "get"), "forType",
+                                    NodeList.nodeList(new StringLiteralExpr(objectClass.getName()))), "apply",
+                                    NodeList.nodeList(new StringLiteralExpr().setString(str))));
         } else {
             return new StringLiteralExpr().setString(object.toString());
         }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageProducerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageProducerJavaTemplate.java
@@ -20,6 +20,7 @@ package com.myspace.demo;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Map;
 
 import org.kie.kogito.event.EventMarshaller;
 import org.kie.kogito.event.impl.StringEventMarshaller;
@@ -39,7 +40,8 @@ public class MessageProducer extends org.kie.kogito.event.impl.AbstractMessagePr
 
     }
 
-    public void produce(KogitoProcessInstance pi, $Type$ eventData) {
+    @Override
+    public void produce(KogitoProcessInstance pi, $Type$ eventData, Map<String, Object> contextAttrs) {
 
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -187,7 +187,8 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
 
     private NodeFactory<?, ?> getActionNode(RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,
             EventRef eventRef, String inputVar) {
-        return sendEventNode(embeddedSubProcess.actionNode(parserContext.newId()), eventDefinition(eventRef.getTriggerEventRef()), eventRef.getData(), inputVar);
+        return sendEventNode(
+                embeddedSubProcess.actionNode(parserContext.newId()), eventDefinition(eventRef.getTriggerEventRef()), eventRef.getData(), eventRef.getContextAttributes(), inputVar);
     }
 
     private NodeFactory<?, ?> getActionNode(RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -133,15 +133,16 @@ public abstract class StateHandler<S extends State> {
 
     protected final <T extends NodeFactory<?, ?> & SupportsAction<?, ?>>
             NodeFactory<?, ?> sendEventNode(T actionNode, ProduceEvent event) {
-        return sendEventNode(actionNode, eventDefinition(event.getEventRef()), event.getData(), DEFAULT_WORKFLOW_VAR);
+        return sendEventNode(actionNode, eventDefinition(event.getEventRef()), event.getData(), event.getContextAttributes(), DEFAULT_WORKFLOW_VAR);
     }
 
     protected final <T extends NodeFactory<?, ?> & SupportsAction<?, ?>> NodeFactory<?, ?> sendEventNode(T actionNode,
             EventDefinition eventDefinition,
             JsonNode data,
+            Map<String, String> contextAttributes,
             String defaultWorkflowVar) {
         return NodeFactoryUtils.sendEventNode(
-                actionNode.action(new ProduceEventActionSupplier(workflow, eventDefinition.getType(), defaultWorkflowVar, data)),
+                actionNode.action(new ProduceEventActionSupplier(workflow, eventDefinition.getType(), defaultWorkflowVar, data, contextAttributes)),
                 eventDefinition,
                 defaultWorkflowVar);
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ProduceEventActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ProduceEventActionSupplier.java
@@ -19,6 +19,8 @@
 package org.kie.kogito.serverless.workflow.suppliers;
 
 import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.jbpm.compiler.canonical.AbstractNodeVisitor;
@@ -26,7 +28,7 @@ import org.jbpm.compiler.canonical.ExpressionSupplier;
 import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.TriggerMetaData;
 import org.jbpm.process.core.event.StaticMessageProducer;
-import org.kie.kogito.event.impl.MessageProducer;
+import org.kie.kogito.event.impl.MessageProducerWithContext;
 import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.serverless.workflow.actions.SWFProduceEventAction;
@@ -48,7 +50,11 @@ public class ProduceEventActionSupplier extends SWFProduceEventAction implements
     private static final long serialVersionUID = 1L;
 
     public ProduceEventActionSupplier(Workflow workflow, String trigger, String varName, JsonNode data) {
-        super(trigger, varName, new MessageProducerSupplier(trigger), workflow.getExpressionLang(), data);
+        this(workflow, trigger, varName, data, Collections.emptyMap());
+    }
+
+    public ProduceEventActionSupplier(Workflow workflow, String trigger, String varName, JsonNode data, Map<String, String> contextAttributes) {
+        super(trigger, varName, new MessageProducerSupplier(trigger), workflow.getExpressionLang(), data, contextAttributes);
     }
 
     @Override
@@ -65,9 +71,9 @@ public class ProduceEventActionSupplier extends SWFProduceEventAction implements
         }
     }
 
-    private static class MessageProducerSupplier implements Supplier<MessageProducer<JsonNode>> {
+    private static class MessageProducerSupplier implements Supplier<MessageProducerWithContext<JsonNode>> {
 
-        private MessageProducer<JsonNode> producer;
+        private MessageProducerWithContext<JsonNode> producer;
         private final String trigger;
 
         public MessageProducerSupplier(String trigger) {
@@ -75,7 +81,7 @@ public class ProduceEventActionSupplier extends SWFProduceEventAction implements
         }
 
         @Override
-        public MessageProducer<JsonNode> get() {
+        public MessageProducerWithContext<JsonNode> get() {
             if (producer == null) {
                 producer = new StaticMessageProducer<>(trigger);
             }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/CloudEventReceiver.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/CloudEventReceiver.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.kie.kogito.serverless.workflow.executor;
+package org.kie.kogito.serverless.workflow.executor.events;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,21 +39,10 @@ import org.slf4j.LoggerFactory;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.CloudEventData;
 
-public class KafkaEventReceiver implements EventReceiver {
+public class CloudEventReceiver implements EventReceiver {
 
-    private static final Logger logger = LoggerFactory.getLogger(KafkaEventReceiver.class);
-    private final Collection<Subscription<?, CloudEvent>> subscriptions = new ArrayList<>();
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void onEvent(CloudEvent value) {
-        for (Subscription subscription : subscriptions) {
-            try {
-                subscription.getConsumer().apply(subscription.getConverter().convert(value));
-            } catch (IOException e) {
-                logger.info("Problem deserializing event {}", value, e);
-            }
-        }
-    }
+    private static final Logger logger = LoggerFactory.getLogger(CloudEventReceiver.class);
+    protected final Collection<Subscription<?, CloudEvent>> subscriptions = new ArrayList<>();
 
     @Override
     public <T> void subscribe(Function<DataEvent<T>, CompletionStage<?>> consumer, Class<T> dataClass) {
@@ -78,5 +67,16 @@ public class KafkaEventReceiver implements EventReceiver {
                 };
             }
         })));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void onEvent(CloudEvent value) {
+        for (Subscription subscription : subscriptions) {
+            try {
+                subscription.getConsumer().apply(subscription.getConverter().convert(value));
+            } catch (IOException e) {
+                logger.info("Problem deserializing event {}", value, e);
+            }
+        }
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventEmitter.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventEmitter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.serverless.workflow.executor.events;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.kie.kogito.event.DataEvent;
+import org.kie.kogito.event.EventEmitter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.cloudevents.jackson.JsonCloudEventData;
+
+public class InMemoryEventEmitter implements EventEmitter {
+
+    private CloudEventReceiver eventReceiver;
+
+    InMemoryEventEmitter(CloudEventReceiver eventReceiver) {
+        this.eventReceiver = eventReceiver;
+    }
+
+    @Override
+    public CompletionStage<Void> emit(DataEvent<?> dataEvent) {
+        eventReceiver.onEvent(dataEvent.asCloudEvent(o -> JsonCloudEventData.wrap((JsonNode) o)));
+        return CompletableFuture.completedStage(null);
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventEmitterFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventEmitterFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.serverless.workflow.executor.events;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.kie.kogito.event.EventEmitter;
+import org.kie.kogito.event.EventEmitterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryEventEmitterFactory implements EventEmitterFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(InMemoryEventEmitterFactory.class);
+
+    private Map<String, EventEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public EventEmitter apply(String trigger) {
+        return emitters.computeIfAbsent(trigger, t -> {
+            CloudEventReceiver eventReceiver = InMemoryEventShared.INSTANCE.receivers().get(trigger);
+            if (eventReceiver != null) {
+                return new InMemoryEventEmitter(eventReceiver);
+            } else {
+                logger.warn("Unregisterd event type {}", trigger);
+                return null;
+            }
+        });
+
+    }
+
+    // lower priority
+    public int ordinal() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventReceiverFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventReceiverFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.serverless.workflow.executor.events;
+
+import org.kie.kogito.event.EventReceiver;
+import org.kie.kogito.event.EventReceiverFactory;
+
+public class InMemoryEventReceiverFactory implements EventReceiverFactory {
+
+    @Override
+    public EventReceiver apply(String trigger) {
+        return InMemoryEventShared.INSTANCE.receivers().computeIfAbsent(trigger, t -> new CloudEventReceiver());
+    }
+
+    // lower priority
+    public int ordinal() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventShared.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/events/InMemoryEventShared.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.serverless.workflow.executor.events;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryEventShared {
+
+    public static final InMemoryEventShared INSTANCE = new InMemoryEventShared();
+
+    private Map<String, CloudEventReceiver> receivers = new ConcurrentHashMap<>();
+
+    public Map<String, CloudEventReceiver> receivers() {
+        return receivers;
+    }
+
+    private InMemoryEventShared() {
+
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/resources/META-INF/services/org.kie.kogito.event.EventEmitterFactory
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/resources/META-INF/services/org.kie.kogito.event.EventEmitterFactory
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.kie.kogito.serverless.workflow.executor.events.InMemoryEventEmitterFactory

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/resources/META-INF/services/org.kie.kogito.event.EventReceiverFactory
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/resources/META-INF/services/org.kie.kogito.event.EventReceiverFactory
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.kie.kogito.serverless.workflow.executor.events.InMemoryEventReceiverFactory

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/src/main/java/org/kie/kogito/serverless/workflow/executor/KafkaEventReceiverFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/src/main/java/org/kie/kogito/serverless/workflow/executor/KafkaEventReceiverFactory.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.kie.kogito.event.EventReceiver;
 import org.kie.kogito.event.EventReceiverFactory;
+import org.kie.kogito.serverless.workflow.executor.events.CloudEventReceiver;
 import org.kie.kogito.serverless.workflow.utils.ConfigResolverHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,14 +41,14 @@ public class KafkaEventReceiverFactory implements EventReceiverFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaEventReceiverFactory.class);
     private Map<String, String> trigger2Topic = KafkaPropertiesFactory.get().triggerToTopicMap("kogito.addon.messaging.incoming.trigger.");
-    private Map<String, KafkaEventReceiver> receivers = new ConcurrentHashMap<>();
+    private Map<String, CloudEventReceiver> receivers = new ConcurrentHashMap<>();
     private Consumer<byte[], CloudEvent> consumer;
     private Lock consumerLock = new ReentrantLock();
     private Thread consumerThread;
 
     @Override
     public EventReceiver apply(String trigger) {
-        return receivers.computeIfAbsent(trigger2Topic.getOrDefault(trigger, trigger), k -> new KafkaEventReceiver());
+        return receivers.computeIfAbsent(trigger2Topic.getOrDefault(trigger, trigger), k -> new CloudEventReceiver());
     }
 
     @Override
@@ -111,7 +112,7 @@ public class KafkaEventReceiverFactory implements EventReceiverFactory {
             }
             for (ConsumerRecord<byte[], CloudEvent> record : records) {
                 String topic = record.topic();
-                KafkaEventReceiver receiver = receivers.get(topic);
+                CloudEventReceiver receiver = receivers.get(topic);
                 if (receiver == null) {
                     logger.info("No subscription for topic {}", topic);
                 } else {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-fluent/src/main/java/org/kie/kogito/serverless/workflow/fluent/ActionBuilder.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-fluent/src/main/java/org/kie/kogito/serverless/workflow/fluent/ActionBuilder.java
@@ -19,8 +19,11 @@
 package org.kie.kogito.serverless.workflow.fluent;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
+import org.kie.kogito.event.cloudevents.CloudEventExtensionConstants;
 import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.process.Process;
@@ -76,7 +79,15 @@ public class ActionBuilder {
     }
 
     public static ActionBuilder trigger(EventDefBuilder builder, JsonNode data) {
-        ActionBuilder actionBuilder = new ActionBuilder(new Action().withEventRef(new EventRef().withData(data).withTriggerEventRef(builder.getName())));
+        return trigger(builder, data, Collections.emptyMap());
+    }
+
+    public static ActionBuilder trigger(EventDefBuilder builder, JsonNode data, String procRefId) {
+        return trigger(builder, data, Map.of(CloudEventExtensionConstants.PROCESS_REFERENCE_ID, procRefId));
+    }
+
+    public static ActionBuilder trigger(EventDefBuilder builder, JsonNode data, Map<String, String> contextAttributes) {
+        ActionBuilder actionBuilder = new ActionBuilder(new Action().withEventRef(new EventRef().withContextAttributes(contextAttributes).withData(data).withTriggerEventRef(builder.getName())));
         actionBuilder.eventDefinition = Optional.of(builder);
         return actionBuilder;
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/SWFProduceEventAction.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/SWFProduceEventAction.java
@@ -18,7 +18,6 @@
  */
 package org.kie.kogito.serverless.workflow.actions;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -36,21 +35,13 @@ public class SWFProduceEventAction extends ProduceEventAction<JsonNode> {
 
     protected final String exprLang;
     protected final JsonNode data;
-    protected final Map<String, String> contextAttrs;
+    protected final JsonNode contextAttrs;
 
-    public SWFProduceEventAction(String triggerName, String varName, Supplier<MessageProducerWithContext<JsonNode>> supplier, String exprLang, JsonNode data) {
-        this(triggerName, varName, supplier, exprLang, data, Map.of());
-    }
-
-    public SWFProduceEventAction(String triggerName, String varName, Supplier<MessageProducerWithContext<JsonNode>> supplier, String exprLang, JsonNode data, Map<String, String> contextAttrs) {
+    public SWFProduceEventAction(String triggerName, String varName, Supplier<MessageProducerWithContext<JsonNode>> supplier, String exprLang, JsonNode data, JsonNode contextAttrs) {
         super(triggerName, varName, supplier);
         this.exprLang = exprLang;
         this.data = data;
         this.contextAttrs = contextAttrs;
-    }
-
-    private static Map<String, Object> toObjectMap(Map<String, String> contextAttrs) {
-        return Collections.<String, Object> unmodifiableMap(contextAttrs);
     }
 
     @Override
@@ -60,9 +51,7 @@ public class SWFProduceEventAction extends ProduceEventAction<JsonNode> {
 
     @Override
     protected Map<String, Object> getContextAttrs(Object object, KogitoProcessContext context) {
-        return contextAttrs != null && !contextAttrs.isEmpty()
-                ? (Map<String, Object>) JsonObjectUtils.toJavaValue(
-                        JsonNodeVisitor.transformNode(JsonObjectUtils.fromValue(contextAttrs), node -> ExpressionHandlerUtils.transform(node, object, context, exprLang), JsonNode::isTextual))
-                : toObjectMap(contextAttrs);
+        return (Map<String, Object>) JsonObjectUtils
+                .toJavaValue(JsonNodeVisitor.transformNode(JsonObjectUtils.fromValue(contextAttrs), node -> ExpressionHandlerUtils.transform(node, object, context, exprLang), JsonNode::isTextual));
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/StringConverter.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/StringConverter.java
@@ -28,7 +28,7 @@ public class StringConverter implements Function<JsonNode, String> {
     @Override
     public String apply(JsonNode t) {
         try {
-            return JsonObjectUtils.toString(t);
+            return t.isNull() ? null : JsonObjectUtils.toString(t);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Invalid value for json node " + t);
         }


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-runtimes/issues/3971
This adds also support for [EventRef.contextAttributes](https://github.com/serverlessworkflow/specification/blob/0.8.x/specification.md#eventref-definition), which is needed to be able to include the target process intances id to be notified by an event.  
However, this support has not been added to the codegen, that will be done with https://github.com/apache/incubator-kie-kogito-runtimes/issues/3973