### PR TITLE
[incubator-kie-issues-2032] Clear actual owner after reassign

### DIFF
--- a/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/lifecycle/DefaultUserTaskLifeCycle.java
+++ b/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/lifecycle/DefaultUserTaskLifeCycle.java
@@ -148,6 +148,7 @@ public class DefaultUserTaskLifeCycle implements UserTaskLifeCycle {
         }
         userTaskInstance.startNotStartedDeadlines();
         userTaskInstance.startNotStartedReassignments();
+        userTaskInstance.setActualOwner(null);
         return Optional.empty();
     }
 


### PR DESCRIPTION
This issue has been identified in some tests by Santander devs while evaluating the reassignments feature.

Santander want to have User tasks reassigned to a group at the end of day if the task isn't completed. To do so they are adding reassignments on the Usertasks.

Apparently, after the reassignment is applied, the task is released (not reserved by the user) but the actual owner is still set.