### PR TITLE
[Resolves #4002] Don't acknowledge the event if it cannot/is not ready to be consumed

### DIFF
--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/ProcessEventDispatcher.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/ProcessEventDispatcher.java
@@ -37,6 +37,7 @@ import org.kie.kogito.correlation.CorrelationInstance;
 import org.kie.kogito.correlation.SimpleCorrelation;
 import org.kie.kogito.event.DataEvent;
 import org.kie.kogito.event.EventDispatcher;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.ProcessService;
@@ -105,11 +106,17 @@ public class ProcessEventDispatcher<M extends Model, D> implements EventDispatch
     private Optional<ProcessInstance<M>> findById(String id) {
         LOGGER.debug("Received message with process instance id '{}'", id);
         Optional<ProcessInstance<M>> result = process.instances().findById(id);
+
+        result.ifPresent(processInstance -> {
+            if (processInstance.status() != KogitoProcessInstance.STATE_ACTIVE) {
+                throw new IllegalStateException("Current process instance is not active");
+            }
+        });
+
         if (LOGGER.isDebugEnabled() && result.isEmpty()) {
             LOGGER.debug("No instance found for process instance id '{}'", id);
         }
         return result;
-
     }
 
     private Optional<ProcessInstance<M>> findByBusinessKey(String key) {

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/ProcessEventDispatcher.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/impl/ProcessEventDispatcher.java
@@ -109,7 +109,7 @@ public class ProcessEventDispatcher<M extends Model, D> implements EventDispatch
 
         result.ifPresent(processInstance -> {
             if (processInstance.status() != KogitoProcessInstance.STATE_ACTIVE) {
-                throw new IllegalStateException("Current process instance is not active");
+                throw new IllegalStateException(String.format("Process instance with id %s is not active", id));
             }
         });
 

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/ProcessEventDispatcherTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/ProcessEventDispatcherTest.java
@@ -47,6 +47,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -72,6 +73,7 @@ class ProcessEventDispatcherTest {
         process = mock(Process.class);
         processInstances = mock(ProcessInstances.class);
         processInstance = mock(ProcessInstance.class);
+        when(processInstance.status()).thenReturn(KogitoProcessInstance.STATE_ACTIVE);
         when(processInstance.id()).thenReturn("1");
         when(process.instances()).thenReturn(processInstances);
         correlationService = spy(new DefaultCorrelationService());
@@ -251,5 +253,28 @@ class ProcessEventDispatcherTest {
         assertThat(signal.getValue()).isEqualTo("Message-" + DUMMY_TOPIC);
         assertThat(processInstanceId.getValue()).isEqualTo("1");
         assertThat(processInstance).isEqualTo(instance);
+    }
+
+    @Test
+    void testSigCloudEventWithInactiveProcessInstance() throws Exception {
+        // Setup inactive process instance
+        ProcessInstance<DummyModel> inactiveProcessInstance = mock(ProcessInstance.class);
+        when(inactiveProcessInstance.id()).thenReturn("2");
+        when(inactiveProcessInstance.status()).thenReturn(KogitoProcessInstance.STATE_COMPLETED);
+        when(processInstances.findById("2")).thenReturn(Optional.of(inactiveProcessInstance));
+
+        EventDispatcher<DummyModel, TestEvent> dispatcher = new ProcessEventDispatcher<>(process, Optional.empty(), processService, executor, null, o -> o.getData());
+        TestCloudEvent<TestEvent> event = new TestCloudEvent<>(new TestEvent("pepe"), DUMMY_TOPIC, "source", "2");
+
+        try {
+            dispatcher.dispatch(DUMMY_TOPIC, event).toCompletableFuture().get();
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).contains("Current process instance is not active");
+        } catch (Exception e) {
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }
+
+        verify(processService, never()).signalProcessInstance(any(), any(), any(), any());
+        verify(processService, never()).createProcessInstance(any(), any(), any(), any(), any(), any(), any(), any());
     }
 }

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/ProcessEventDispatcherTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/ProcessEventDispatcherTest.java
@@ -39,6 +39,7 @@ import org.kie.kogito.correlation.SimpleCorrelation;
 import org.kie.kogito.event.DataEventFactory;
 import org.kie.kogito.event.EventDispatcher;
 import org.kie.kogito.event.correlation.DefaultCorrelationService;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.ProcessInstances;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -682,7 +682,7 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
         logger.debug("Signal {} received with data {} in process instance {}", type, event, getStringId());
         synchronized (this) {
             if (getState() != KogitoProcessInstance.STATE_ACTIVE) {
-                return;
+                throw new IllegalStateException("Current process instance state is not active");
             }
 
             if (TIMER_TRIGGERED_EVENT.equals(type)) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -682,7 +682,7 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
         logger.debug("Signal {} received with data {} in process instance {}", type, event, getStringId());
         synchronized (this) {
             if (getState() != KogitoProcessInstance.STATE_ACTIVE) {
-                throw new IllegalStateException("Current process instance state is not active");
+                return;
             }
 
             if (TIMER_TRIGGERED_EVENT.equals(type)) {

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
@@ -57,7 +57,7 @@ public abstract class AbstractQuarkusCloudEventReceiver<I> implements EventRecei
     protected CompletionStage<?> produce(final Message<I> message) {
         LOGGER.debug("Received message {}", message);
         return produce(message, (v, e) -> {
-            if (e != null) {
+            if (e != null && e.getCause() != null && e.getCause() instanceof IllegalStateException) {
                 LOGGER.error("Error processing message {}", message.getPayload(), e);
                 message.nack(e);
             } else {

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
@@ -57,10 +57,14 @@ public abstract class AbstractQuarkusCloudEventReceiver<I> implements EventRecei
     protected CompletionStage<?> produce(final Message<I> message) {
         LOGGER.debug("Received message {}", message);
         return produce(message, (v, e) -> {
-            LOGGER.debug("Acking message {}", message);
             message.ack();
             if (e != null) {
                 LOGGER.error("Error processing message {}", message.getPayload(), e);
+                LOGGER.debug("NonAcking message {}", message);
+                message.nack(e);
+            } else {
+                LOGGER.debug("Acking message {}", message);
+                message.ack();
             }
         });
     }

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
@@ -59,7 +59,6 @@ public abstract class AbstractQuarkusCloudEventReceiver<I> implements EventRecei
         return produce(message, (v, e) -> {
             if (e != null) {
                 LOGGER.error("Error processing message {}", message.getPayload(), e);
-                LOGGER.debug("NonAcking message {}", message);
                 message.nack(e);
             } else {
                 LOGGER.debug("Acking message {}", message);

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventReceiver.java
@@ -57,7 +57,6 @@ public abstract class AbstractQuarkusCloudEventReceiver<I> implements EventRecei
     protected CompletionStage<?> produce(final Message<I> message) {
         LOGGER.debug("Received message {}", message);
         return produce(message, (v, e) -> {
-            message.ack();
             if (e != null) {
                 LOGGER.error("Error processing message {}", message.getPayload(), e);
                 LOGGER.debug("NonAcking message {}", message);


### PR DESCRIPTION
Resolves #4002 

If an event is not ready/cannot be consumed, that event should not be acknowledged.