### PR TITLE
[incubator-kie-issues#2047] Java 21 Support

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -57,8 +57,6 @@
     <container.image.postgres>postgres:${version.org.postgres}</container.image.postgres>
 
     <maven.compiler.release>17</maven.compiler.release>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
     <jacoco.agent.argLine/>
     <!--
       JaCoCo coverage data file location. Using a single file for appending in the project's root directory makes it
@@ -71,7 +69,7 @@
     <formatter.skip>false</formatter.skip>
     <formatter.goal>format</formatter.goal>
     <impsort.goal>sort</impsort.goal>
-    <version.jdk>17</version.jdk>
+    <version.jdk>${maven.compiler.release}</version.jdk>
     <!-- Properties also affecting test execution. -->
     <invoker.skip>false</invoker.skip>
     <archetype.test.skip>false</archetype.test.skip>
@@ -641,6 +639,9 @@
               </goals>
             </execution>
           </executions>
+          <configuration>
+            <targetBytecode>${maven.compiler.release}</targetBytecode>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -81,10 +81,10 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(defaultValue = "3.10.2", property = "version.compiler.plugin")
     private String compilerPluginVersion;
 
-    @Parameter(defaultValue = "17", property = "maven.compiler.source")
+    @Parameter(defaultValue = "17", property = "maven.compiler.release")
     private String compilerSourceJavaVersion;
 
-    @Parameter(defaultValue = "17", property = "maven.compiler.target")
+    @Parameter(defaultValue = "17", property = "maven.compiler.release")
     private String compilerTargetJavaVersion;
 
     @Component

--- a/quarkus/extensions/kogito-quarkus-test-list/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
@@ -37,8 +37,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
     <test.list.file.location>${project.build.directory}/kogito-quarkus-test-list.xml</test.list.file.location>
   </properties>
 

--- a/springboot/archetype/pom.xml
+++ b/springboot/archetype/pom.xml
@@ -27,13 +27,11 @@
     <artifactId>springboot</artifactId>
     <version>999-SNAPSHOT</version>
   </parent>
+
   <artifactId>kogito-spring-boot-archetype</artifactId>
   <packaging>maven-archetype</packaging>
   <name>Kogito :: Spring Boot :: Maven Archetype</name>
   <description>Kogito based on Spring Boot runtime Archetype</description>
-
-
-
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2047

As Java 21 is the latest Java LTS available, already for some time the code should be buildable and runnable with Java 21, while still retaining compatibility with Java 17.