### PR TITLE
[incubator-kie-issues#2060] Generate SourceFilesProvider when there are no models in the Business Service project

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/DummyProcess.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/DummyProcess.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.kie.kogito.codegen.process;
+
+import java.util.List;
+import java.util.Map;
+
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.WorkflowElementIdentifier;
+import org.kie.api.io.Resource;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
+
+/**
+ * Class used as "placeholder" in case there are no processes in the application but
+ * kie-addons-quarkus-source-files is present.
+ * Temporary hack for incubator-kie-issues#2060
+ */
+public class DummyProcess implements KogitoWorkflowProcess {
+
+    @Override
+    public String getVisibility() {
+        return "";
+    }
+
+    @Override
+    public List<Node> getNodesRecursively() {
+        return List.of();
+    }
+
+    @Override
+    public Node[] getNodes() {
+        return new Node[0];
+    }
+
+    @Override
+    public Node getNode(WorkflowElementIdentifier workflowElementIdentifier) {
+        return null;
+    }
+
+    @Override
+    public Node getNodeByUniqueId(String s) {
+        return null;
+    }
+
+    @Override
+    public KnowledgeType getKnowledgeType() {
+        return null;
+    }
+
+    @Override
+    public String getNamespace() {
+        return "dummy-namespace";
+    }
+
+    @Override
+    public String getId() {
+        return "dummy-id";
+    }
+
+    @Override
+    public String getName() {
+        return "dummy-name";
+    }
+
+    @Override
+    public String getVersion() {
+        return "dummy-version";
+    }
+
+    @Override
+    public String getPackageName() {
+        return "dummy-package-name";
+    }
+
+    @Override
+    public String getType() {
+        return "dummy-type";
+    }
+
+    @Override
+    public Map<String, Object> getMetaData() {
+        return Map.of();
+    }
+
+    @Override
+    public Resource getResource() {
+        return null;
+    }
+
+    @Override
+    public void setResource(Resource resource) {
+
+    }
+}

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/util/SourceFilesProviderProducerUtil.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/util/SourceFilesProviderProducerUtil.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.kie.api.io.Resource;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.codegen.process.DummyProcess;
 import org.kie.kogito.codegen.process.ProcessCodegenException;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
 
@@ -61,7 +62,7 @@ public class SourceFilesProviderProducerUtil {
                 .findFirst()
                 .orElseThrow(() -> new ProcessCodegenException("SourceFileProviderProducerTemplate does not contain a class declaration"));
 
-        if (workflows.isEmpty()) {
+        if (workflows.isEmpty() || workflows.values().stream().allMatch(DummyProcess.class::isInstance)) { // Temporary hack for incubator-kie-issues#2060
             producerClass.remove(staticInitDeclaration);
         } else {
             registerWorkflows(staticInitDeclaration, workflows, context);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2060

This PR:
1. introduce a `DummyProcess` class to instantaite as placeholder when there are no bpmn models in the application but the kie-addons-quarkus-source-files is present
2. in the above case, all check and code-generation are skept
3. the generated `SourceFilesProviderProducer` does not have the static initializer, so that the retrieved `SourceFilesProvider` does not have any content
4. I also tested locally native build§
5. this is meant as temporary solution to unlock other PRs, because IMO the overall approach and design has to be reviewed by SMEs (e.g. - all the add-ons are actually "plugins", but their code is implemented in the core itself)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


