### PR TITLE
Fixes for supporting native mode

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceFactoryRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceFactoryRegistry.java
@@ -33,6 +33,9 @@ public class NodeInstanceFactoryRegistry {
     private static final NodeInstanceFactoryRegistry INSTANCE = new NodeInstanceFactoryRegistry();
 
     private static final Map<String, NodeInstanceFactoryRegistry> LOADED_NODE_INSTANCE_FACTORY_REGISTRIES = new HashMap<>();
+    static {
+        LOADED_NODE_INSTANCE_FACTORY_REGISTRIES.put(CodegenNodeInstanceFactoryRegistry.class.getName(), new CodegenNodeInstanceFactoryRegistry());
+    }
 
     private final Map<Class<? extends Node>, NodeInstanceFactory> registry;
 

--- a/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/DefaultUserTaskInstance.java
+++ b/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/DefaultUserTaskInstance.java
@@ -55,12 +55,15 @@ import org.kie.kogito.usertask.model.ScheduleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import static java.util.Collections.emptyMap;
 import static org.kie.kogito.jobs.descriptors.UserTaskInstanceJobDescription.newUserTaskInstanceJobDescriptionBuilder;
 import static org.kie.kogito.usertask.impl.lifecycle.DefaultUserTaskLifeCycle.WORKFLOW_ENGINE_USER;
 
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 public class DefaultUserTaskInstance implements UserTaskInstance {
 
     private static Logger LOG = LoggerFactory.getLogger(DefaultUserTaskInstance.class);

--- a/jbpm/jbpm-usertask/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/jbpm/jbpm-usertask/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "org.kie.kogito.usertask.impl.DefaultUserTaskInstance",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  }
+]


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2056

Issue 1: To fix 
`java.lang.ClassNotFoundException: org.jbpm.workflow.instance.impl.CodegenNodeInstanceFactoryRegistry`

when running process examples in native mode, initialize map `LOADED_NODE_INSTANCE_FACTORY_REGISTRIES` with the object of `CodegenNodeInstanceFactoryRegistry` class using new keyword

Issue 2: to fix serialization and reflection issue on `DefaultUserTaskInstance`, added `reflect-config.json`




