### PR TITLE
[Fix #4024] Allowing multiple parameters on python invocation

### DIFF
--- a/quarkus/addons/python/integration-tests/src/main/resources/PythonService.sw.json
+++ b/quarkus/addons/python/integration-tests/src/main/resources/PythonService.sw.json
@@ -5,7 +5,17 @@
     "name" : "factorial",
     "operation" : "service:python:math::factorial",
     "type" : "custom"
-  } ],
+   },
+   {
+     "name" : "module",
+     "operation" : "service:python:math::fmod",
+     "type" : "custom"
+   },
+   {
+     "name" : "isClose",
+     "operation" : "service:python:math::isclose",
+     "type" : "custom"
+   } ],
   "states" : [ {
     "actions" : [ {
       "functionRef" : {
@@ -13,9 +23,27 @@
           "arguments" : ".x"
        },
       "actionDataFilter" : {
-        "toStateData" : ".result"
+        "toStateData" : ".factorial"
       }
-    } ],
+    },
+    {  
+      "functionRef" : {
+          "refName": "module",
+          "arguments" : [".x",".y"]
+      },
+      "actionDataFilter" : {
+        "toStateData" : ".module"
+      }
+    }, 
+    {  
+       "functionRef" : {
+         "refName": "isClose",
+            "arguments" : {"a": ".x", "b":".y", "abs_tol": 2.1}
+       },
+       "actionDataFilter" : {
+         "toStateData" : ".isClose"
+       }
+     }],
     "name" : "operation_1",
     "type" : "operation",
     "end" : true

--- a/quarkus/addons/python/integration-tests/src/test/java/org/kie/kogito/quarkus/workflows/PythonFlowIT.java
+++ b/quarkus/addons/python/integration-tests/src/test/java/org/kie/kogito/quarkus/workflows/PythonFlowIT.java
@@ -37,7 +37,7 @@ class PythonFlowIT {
 
     @Test
     void testPythonService() {
-        given().contentType(ContentType.JSON).accept(ContentType.JSON).body("{\"x\" : 5}").post("/Factorial")
-                .then().statusCode(201).body("workflowdata.result", is(120));
+        given().contentType(ContentType.JSON).accept(ContentType.JSON).body("{\"x\" : 5, \"y\":3}").post("/Factorial")
+                .then().statusCode(201).body("workflowdata.factorial", is(120)).body("workflowdata.module", is(2.0f)).body("workflowdata.isClose", is(true));
     }
 }


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-runtimes/issues/4024

In order to specify multiple positional parameters, user should pass an array.

Note that keyword parameters was already supported

