### PR TITLE
Add a process configuration option for getter prefix for Boolean object

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
@@ -29,6 +29,8 @@ public final class ContextAttributesConstants {
 
     public static final String KOGITO_FAULT_TOLERANCE_ENABLED = "kogito.faultToleranceEnabled";
 
+    public static final String KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR = "kogito.codegen.booleanObjectAccessorBehaviour";
+
     private ContextAttributesConstants() {
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/marshaller/AbstractMarshallerGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/marshaller/AbstractMarshallerGenerator.java
@@ -48,6 +48,7 @@ import org.kie.kogito.codegen.api.template.InvalidTemplateException;
 import org.kie.kogito.codegen.api.template.TemplatedGenerator;
 import org.kie.kogito.codegen.core.BodyDeclarationComparator;
 import org.kie.kogito.codegen.process.persistence.ExclusionTypeUtils;
+import org.kie.kogito.codegen.process.util.CodegenUtil;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
@@ -79,6 +80,7 @@ import static com.github.javaparser.ast.Modifier.Keyword.PUBLIC;
 import static com.github.javaparser.ast.expr.BinaryExpr.Operator.EQUALS;
 import static java.lang.String.format;
 import static org.kie.kogito.codegen.process.persistence.proto.ProtoGenerator.KOGITO_JAVA_CLASS_OPTION;
+import static org.kie.kogito.codegen.process.persistence.proto.ProtoGenerator.KOGITO_JAVA_TYPE_BOOLEAN_OBJECT_OPTION;
 
 public abstract class AbstractMarshallerGenerator<T> implements MarshallerGenerator {
 
@@ -123,6 +125,7 @@ public abstract class AbstractMarshallerGenerator<T> implements MarshallerGenera
         serializationContext.registerProtoFiles(proto);
 
         Map<String, FileDescriptor> descriptors = serializationContext.getFileDescriptors();
+        String booleanObjectAccessorProperty = CodegenUtil.getBooleanObjectAccessor(context);
 
         for (Entry<String, FileDescriptor> entry : descriptors.entrySet()) {
 
@@ -184,7 +187,10 @@ public abstract class AbstractMarshallerGenerator<T> implements MarshallerGenera
                         // has a mapped type
                         read = new MethodCallExpr(new NameExpr("reader"), "read" + protoStreamMethodType)
                                 .addArgument(new StringLiteralExpr(field.getName()));
-                        String accessor = protoStreamMethodType.equals("Boolean") ? "is" : "get";
+                                
+                        String accessor = protoStreamMethodType.equals("Boolean")?(field.getOptionByName(KOGITO_JAVA_TYPE_BOOLEAN_OBJECT_OPTION) != null ?
+                            booleanObjectAccessorProperty: "is") : "get";
+
                         write = new MethodCallExpr(new NameExpr("writer"), "write" + protoStreamMethodType)
                                 .addArgument(new StringLiteralExpr(field.getName()))
                                 .addArgument(new MethodCallExpr(new NameExpr("t"), accessor + StringUtils.ucFirst(field.getName())));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/proto/ProtoGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/proto/ProtoGenerator.java
@@ -29,6 +29,7 @@ public interface ProtoGenerator {
     GeneratedFileType PROTO_TYPE = GeneratedFileType.of("PROTO", GeneratedFileType.Category.STATIC_HTTP_RESOURCE);
     String INDEX_COMMENT = "@Field(index = Index.YES, store = Store.YES) @SortableField";
     String KOGITO_JAVA_CLASS_OPTION = "kogito_java_class";
+    String KOGITO_JAVA_TYPE_BOOLEAN_OBJECT_OPTION = "kogito_java_type_boolean_object";
     String KOGITO_SERIALIZABLE = "kogito.Serializable";
     String ARRAY = "Array";
     String COLLECTION = "Collection";

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/proto/ReflectionProtoGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/proto/ReflectionProtoGenerator.java
@@ -121,7 +121,11 @@ public class ReflectionProtoGenerator extends AbstractProtoGenerator<Class<?>> {
             protoField.setComment(completeFieldComment);
             if (KOGITO_SERIALIZABLE.equals(protoType)) {
                 protoField.setOption(format("[%s = \"%s\"]", KOGITO_JAVA_CLASS_OPTION, pd.getPropertyType().getCanonicalName()));
+                
+            } else if("java.lang.Boolean".equals(fieldTypeString)) {
+                protoField.setOption(format("[%s = \"%s\"]", KOGITO_JAVA_TYPE_BOOLEAN_OBJECT_OPTION, fieldTypeString));
             }
+
         }
         message.setComment(messageComment);
         proto.addMessage(message);

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/util/CodegenUtil.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/util/CodegenUtil.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.kogito.codegen.api.context.ContextAttributesConstants.KOGITO_FAULT_TOLERANCE_ENABLED;
+import static org.kie.kogito.codegen.api.context.ContextAttributesConstants.KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR;
 
 public final class CodegenUtil {
 
@@ -123,4 +124,19 @@ public final class CodegenUtil {
 
         return !JavaKogitoBuildContext.CONTEXT_NAME.equals(context.name()) && isFaultToleranceEnabled;
     }
+
+    public static String getBooleanObjectAccessor(KogitoBuildContext context) {
+        return context.getApplicationProperty(KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR)
+        .map(value -> {
+            switch (value) {
+                case "isPrefix": return "is";
+                case "javaBeans": return "get";
+                default: throw new IllegalArgumentException(
+                    "Property " + KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR +
+                    " defined but does not contain proper value: expected 'isPrefix' or 'javaBeans'");
+            }
+        })
+        .orElse("is");
+    }
 }
+

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/data/Person.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/data/Person.java
@@ -45,6 +45,7 @@ public class Person {
     private int age;
     private byte[] bytes;
     private boolean adult;
+    private Boolean married;
     private Person parent;
     private Person[] relatives;
     private Instant instant;
@@ -262,6 +263,14 @@ public class Person {
         this.expenses = expenses;
     }
 
+    public Boolean isMarried() {
+        return married;
+    }
+
+    public void setMarried(Boolean married) {
+        this.married = married;
+    }
+
     @Override
     public String toString() {
         return "Person{" +
@@ -269,6 +278,7 @@ public class Person {
                 ", name='" + name + '\'' +
                 ", age=" + age +
                 ", adult=" + adult +
+                ", married=" + married +
                 ", parent=" + parent +
                 ", relatives=" + Arrays.toString(relatives) +
                 ", instant=" + instant +
@@ -292,12 +302,12 @@ public class Person {
         if (o == null || getClass() != o.getClass())
             return false;
         Person person = (Person) o;
-        return age == person.age && adult == person.adult && Objects.equals(name, person.name) && Objects.equals(parent, person.parent) && Objects.equals(ignoreMe, person.ignoreMe)
+        return age == person.age && adult == person.adult && married == person.married && Objects.equals(name, person.name) && Objects.equals(parent, person.parent) && Objects.equals(ignoreMe, person.ignoreMe)
                 && Objects.equals(addresses, person.addresses);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, age, adult, parent, ignoreMe, addresses);
+        return Objects.hash(name, age, adult, married, parent, ignoreMe, addresses);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/data/PersonWithBooleanGetAccessor.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/data/PersonWithBooleanGetAccessor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.codegen.data;
+
+import java.util.Objects;
+
+public class PersonWithBooleanGetAccessor {
+    private String id;
+    private String name;
+    private int age;
+    private boolean adult;
+    private Boolean married;
+
+    public PersonWithBooleanGetAccessor() {
+    }
+
+    public PersonWithBooleanGetAccessor(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public boolean isAdult() {
+        return adult;
+    }
+
+    public void setAdult(boolean adult) {
+        this.adult = adult;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+     public Boolean getMarried() {
+        return married;
+    }
+
+    public void setMarried(Boolean married) {
+        this.married = married;
+    }
+    
+    @Override
+    public String toString() {
+        return "Person{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", age=" + age +
+                ", adult=" + adult +
+                ", married=" + married +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        PersonWithBooleanGetAccessor person = (PersonWithBooleanGetAccessor) o;
+        return age == person.age && adult == person.adult && married == person.married;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, age, adult, married);
+    }
+
+}

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/util/CodegenUtilTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/util/CodegenUtilTest.java
@@ -1,0 +1,36 @@
+package org.kie.kogito.codegen.process.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.kie.kogito.codegen.process.util.CodegenUtil.*;
+import static org.kie.kogito.codegen.api.context.ContextAttributesConstants.KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR;
+
+public class CodegenUtilTest {
+
+    private KogitoBuildContext context;
+
+    @BeforeEach
+    public void setup() {
+        this.context = QuarkusKogitoBuildContext.builder().build();
+    }
+
+    @Test
+    public void testGetBooleanObjectAccessor() {
+        assertEquals("is", getBooleanObjectAccessor(context));
+
+        context.setApplicationProperty(KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR, "javaBeans");
+        assertEquals("get", getBooleanObjectAccessor(context));  
+
+        context.setApplicationProperty(KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR, "isPrefix");
+        assertEquals("is", getBooleanObjectAccessor(context));  
+
+        context.setApplicationProperty(KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR, "get1");
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {getBooleanObjectAccessor(context);});  
+        assertEquals("Property " + KOGITO_CODEGEN_BOOLEAN_OBJECT_ACCESSOR_BEHAVIOUR + " defined but does not contain proper value: expected 'isPrefix' or 'javaBeans'", exception.getMessage());
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie-issues/issues/2041

Current behaviour is , 
By default, the marshaller generates getter methods using the `is` prefix for both primitive `boolean` and boxed `Boolean` fields (e.g., isFieldName).

To support the use of the `get` prefix for `Boolean` objects, a new configuration property has been introduced: `kogito.codegen.booleanObjectAccessorBehaviour,` which accepts two values:

`"isPrefix"` – uses is as the getter prefix

`"javaBeans"` – uses get as the getter prefix

If the property is not set, the default behaviour remains: the `is` prefix is used. If the property is set to any value other than `"isPrefix"` or `"javaBeans"`, an exception will be thrown with the message: `"Property kogito.codegen.booleanObjectAccessorBehaviour defined but does not contain proper value: expected 'isPrefix' or 'javaBeans'"`
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

Many thanks for submitting your Pull Request :heart:! 

<!-- Please don't forget your Issue link -->
Closes/Fixes/Resolves #ISSUE-NUMBER

<!-- Please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/apache/incubator-kie-kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


