### PR TITLE
NO-ISSUE: fix test failures on windows

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/BrokenStructureRefTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/BrokenStructureRefTest.java
@@ -18,6 +18,7 @@
  */
 package org.jbpm.bpmn2;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -31,10 +32,10 @@ public class BrokenStructureRefTest {
 
     @Test
     public void testProcessWithBrokenItemDefinitionUri() throws Exception {
-        String inputBpmn = getClass().getResource("/org/jbpm/bpmn2/flow/BPMN2-BrokenStructureRef.bpmn2").getPath();
+        URL resource = getClass().getResource("/org/jbpm/bpmn2/flow/BPMN2-BrokenStructureRef.bpmn2");
         XmlProcessDumper dumper = XmlProcessDumperFactory.getXmlProcessDumperFactoryService().newXmlProcessDumper();
         assertThat(dumper).isNotNull();
-        String processXml = new String(Files.readAllBytes(Paths.get(inputBpmn)));
+        String processXml = new String(Files.readAllBytes(Paths.get(resource.toURI())));
         assertThat(processXml).isNotNull();
         org.kie.api.definition.process.Process proc = dumper.readProcess(processXml);
         assertThat(proc).isNotNull();

--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -900,7 +900,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
         Files.write(dtdFile.toPath(), dtdContent.getBytes("UTF-8"));
 
-        byte[] data = Files.readAllBytes(Paths.get(this.getClass().getResource("/xxe-protection/BPMN2-XXE-Process.bpmn2").getPath()));
+        byte[] data = Files.readAllBytes(Paths.get(this.getClass().getResource("/xxe-protection/BPMN2-XXE-Process.bpmn2").toURI()));
         String processAsString = new String(data, "UTF-8");
         // replace place holders with actual paths
         File testFiles = new File("src/test/resources/xxe-protection");

--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StartEventTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StartEventTest.java
@@ -152,7 +152,7 @@ public class StartEventTest extends JbpmBpmn2TestCase {
     @Test
     public void testTimerStartDateISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("StartProcess", 1);
-        byte[] content = Files.readAllBytes(Paths.get(this.getClass().getResource("/org/jbpm/bpmn2/start/BPMN2-TimerStartDate.bpmn2").getPath()));
+        byte[] content = Files.readAllBytes(Paths.get(this.getClass().getResource("/org/jbpm/bpmn2/start/BPMN2-TimerStartDate.bpmn2").toURI()));
         String processContent = new String(content, "UTF-8");
 
         OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);

--- a/jbpm/jbpm-usertask/src/test/java/org/kie/kogito/usertask/impl/model/DeadlineHelperTest.java
+++ b/jbpm/jbpm-usertask/src/test/java/org/kie/kogito/usertask/impl/model/DeadlineHelperTest.java
@@ -56,7 +56,7 @@ public class DeadlineHelperTest {
         ExpirationTime time = DeadlineHelper.getExpirationTime(scheduleInfo);
         assertThat(time.repeatInterval()).isEqualTo(5000L);
         assertThat(time.repeatLimit()).isEqualTo(-1);
-        assertThat(ZonedDateTime.now().plus(Duration.ofSeconds(5)).isAfter(time.get())).isTrue();
+        assertThat(ZonedDateTime.now().plus(Duration.ofMillis(5003)).isAfter(time.get())).isTrue();
     }
 
     @Test
@@ -315,7 +315,7 @@ public class DeadlineHelperTest {
         ExpirationTime time = DeadlineHelper.getExpirationTime(scheduleInfo);
         assertThat(time.repeatInterval()).isNull();
         assertThat(time.repeatLimit()).isZero();
-        assertThat(ZonedDateTime.now().plus(Duration.ofMinutes(1)).isAfter(time.get())).isTrue();
+        assertThat(ZonedDateTime.now().plus(Duration.ofMillis(60005)).isAfter(time.get())).isTrue();
     }
 
     @Test

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/CustomDashboardGeneratedUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/CustomDashboardGeneratedUtils.java
@@ -19,7 +19,6 @@
 package org.kie.kogito.codegen.core;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -46,7 +45,7 @@ public class CustomDashboardGeneratedUtils {
     }
 
     private static final Function<Resource, String> grouperFunction = resource -> {
-        String fileName = resource.getSourcePath().substring(resource.getSourcePath().lastIndexOf(File.separator) + 1);
+        String fileName = resource.getSourcePath().substring(resource.getSourcePath().lastIndexOf('/') + 1);
         if (fileName.startsWith(OPERATIONAL_DASHBOARD_PREFIX)) {
             return OPERATIONAL_DASHBOARD_PREFIX;
         } else if (fileName.startsWith(DOMAIN_DASHBOARD_PREFIX)) {
@@ -92,7 +91,7 @@ public class CustomDashboardGeneratedUtils {
                                 StandardCharsets.UTF_8))
                                         .lines()
                                         .collect(Collectors.joining("\n"));
-                String dashboardName = resource.getSourcePath().substring(resource.getSourcePath().lastIndexOf(File.separator) + 1).substring(dashboardPrefix.length());
+                String dashboardName = resource.getSourcePath().substring(resource.getSourcePath().lastIndexOf('/') + 1).substring(dashboardPrefix.length());
                 target.addAll(generator.apply(dashboard, dashboardName));
             } catch (IOException e) {
                 e.printStackTrace();
@@ -109,8 +108,8 @@ public class CustomDashboardGeneratedUtils {
 
     static boolean isValidResource(CollectedResource toVerify) {
         String sourcePath = toVerify.resource().getSourcePath();
-        String fileName = sourcePath.substring(sourcePath.lastIndexOf(File.separator) + 1);
-        return sourcePath.contains("META-INF" + File.separator + "dashboards") &&
+        String fileName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
+        return sourcePath.contains("META-INF/dashboards") &&
                 (fileName.startsWith(OPERATIONAL_DASHBOARD_PREFIX) || fileName.startsWith(DOMAIN_DASHBOARD_PREFIX)) &&
                 fileName.endsWith(".json");
     }

--- a/kogito-codegen-modules/kogito-codegen-core/src/test/java/org/kie/kogito/codegen/core/CustomDashboardGeneratedUtilsTest.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/test/java/org/kie/kogito/codegen/core/CustomDashboardGeneratedUtilsTest.java
@@ -67,7 +67,7 @@ class CustomDashboardGeneratedUtilsTest {
                 OPERATIONAL_DASHBOARD_PREFIX);
         assertThat(toPopulate).hasSameSizeAs(dashboardJsonsMap.get(OPERATIONAL_DASHBOARD_PREFIX));
         String sourcePath = dashboardJsonsMap.get(OPERATIONAL_DASHBOARD_PREFIX).get(0).getSourcePath();
-        String originalFileName = sourcePath.substring(sourcePath.lastIndexOf(File.separator) + 1);
+        String originalFileName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
         validateGeneratedFile(toPopulate.iterator().next(),
                 OPERATIONAL_DASHBOARD_PREFIX,
                 originalFileName);
@@ -77,7 +77,7 @@ class CustomDashboardGeneratedUtilsTest {
                 DOMAIN_DASHBOARD_PREFIX);
         assertThat(toPopulate).hasSameSizeAs(dashboardJsonsMap.get(DOMAIN_DASHBOARD_PREFIX));
         sourcePath = dashboardJsonsMap.get(DOMAIN_DASHBOARD_PREFIX).get(0).getSourcePath();
-        originalFileName = sourcePath.substring(sourcePath.lastIndexOf(File.separator) + 1);
+        originalFileName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
         validateGeneratedFile(toPopulate.iterator().next(),
                 DOMAIN_DASHBOARD_PREFIX,
                 originalFileName);
@@ -102,7 +102,7 @@ class CustomDashboardGeneratedUtilsTest {
         assertThat(toValidate.type().name()).isEqualTo("DASHBOARD");
         assertThat(toValidate.category().name()).isEqualTo("STATIC_HTTP_RESOURCE");
         String fileName =
-                toValidate.relativePath().substring(toValidate.relativePath().lastIndexOf(File.separator) + 1);
+                toValidate.relativePath().substring(toValidate.relativePath().lastIndexOf('/') + 1);
         assertThat(fileName).startsWith(dashboardType)
                 .isEqualTo(originalFileName);
     }

--- a/kogito-codegen-modules/kogito-codegen-predictions/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegenFactory.java
+++ b/kogito-codegen-modules/kogito-codegen-predictions/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegenFactory.java
@@ -18,7 +18,6 @@
  */
 package org.kie.kogito.codegen.prediction;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -101,9 +100,9 @@ public class PredictionCodegenFactory implements GeneratorFactory {
         resources.forEach(resource -> {
             KieMemoryCompiler.MemoryCompilerClassLoader memoryCompilerClassLoader =
                     new KieMemoryCompiler.MemoryCompilerClassLoader(classLoader);
-            String fileName = resource.getSourcePath();
-            if (fileName.contains(File.separator)) {
-                fileName = fileName.substring(fileName.lastIndexOf(File.separator) + 1);
+            String fileName = resource.getSourcePath(); // this is in fact PortablePath instance
+            if (fileName.contains("/")) {
+                fileName = fileName.substring(fileName.lastIndexOf('/') + 1);
             }
             EfestoResource<InputStream> efestoResource;
             PMMLCompilationContext compilationContext = getPMMLCompilationContext(fileName, memoryCompilerClassLoader);

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -21,6 +21,7 @@ package org.kie.kogito.codegen.process;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -116,12 +117,20 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
 
     static Stream<String> processesProvider() throws IOException {
         Set<String> ignoredFiles = Files.lines(BASE_PATH.resolve("org/kie/kogito/codegen/process/process-generation-test.skip.txt"))
+                .filter(it -> {
+                    try {
+                        Path.of(it);
+                        return true;
+                    } catch (InvalidPathException ipe) {
+                        return false;
+                    }
+                })
                 .collect(Collectors.toSet());
         return Files.find(BASE_PATH, 10, ((path, basicFileAttributes) -> basicFileAttributes.isRegularFile()
                 && SupportedExtensions.isSourceFile(path)))
                 .map(BASE_PATH::relativize)
-                .map(Path::toString)
-                .filter(p -> ignoredFiles.stream().noneMatch(ignored -> p.contains(ignored)));
+                .filter(p -> ignoredFiles.stream().noneMatch(ignored -> p.startsWith(ignored)))
+                .map(Path::toString);
     }
 
     @ParameterizedTest

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonSchemaGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonSchemaGeneratorTest.java
@@ -19,6 +19,7 @@
 package org.kie.kogito.codegen.json;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -229,7 +230,7 @@ public class JsonSchemaGeneratorTest {
         Collection<GeneratedFile> files = new JsonSchemaGenerator.ClassBuilder(Stream.of(WhitespacesTask.class)).build().generate();
         assertThat(files).hasSize(1);
         GeneratedFile file = files.iterator().next();
-        assertThat(file.relativePath()).isEqualTo(JsonSchemaUtil.getJsonDir().resolve("InputOutput_name_with_spaces.json").toString());
+        assertThat(Path.of(file.relativePath())).isEqualTo(JsonSchemaUtil.getJsonDir().resolve("InputOutput_name_with_spaces.json"));
     }
 
     @Test
@@ -270,7 +271,7 @@ public class JsonSchemaGeneratorTest {
     }
 
     private void assertEmptyProcessSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion) throws IOException {
-        assertThat(file.relativePath()).isEqualTo(JsonSchemaUtil.getJsonDir().resolve(fileName).toString());
+        assertThat(Path.of(file.relativePath())).isEqualTo(JsonSchemaUtil.getJsonDir().resolve(fileName));
 
         ObjectReader reader = new ObjectMapper().reader();
         JsonNode node = reader.readTree(file.contents());
@@ -281,7 +282,7 @@ public class JsonSchemaGeneratorTest {
     }
 
     private void assertProcessSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion) throws IOException {
-        assertThat(file.relativePath()).isEqualTo(JsonSchemaUtil.getJsonDir().resolve(fileName).toString());
+        assertThat(Path.of(file.relativePath())).isEqualTo(JsonSchemaUtil.getJsonDir().resolve(fileName));
         ObjectReader reader = new ObjectMapper().reader();
         JsonNode node = reader.readTree(file.contents());
         assertThat(node.get("$schema").asText()).isEqualTo(schemaVersion.getIdentifier());
@@ -303,7 +304,7 @@ public class JsonSchemaGeneratorTest {
     }
 
     private void assertTaskSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion, List<String> inputs, List<String> outputs) throws IOException {
-        assertThat(file.relativePath()).isEqualTo(JsonSchemaUtil.getJsonDir().resolve(fileName).toString());
+        assertThat(Path.of(file.relativePath())).isEqualTo(JsonSchemaUtil.getJsonDir().resolve(fileName));
         ObjectReader reader = new ObjectMapper().reader();
         JsonNode node = reader.readTree(file.contents());
         assertThat(node.get("$schema").asText()).isEqualTo(schemaVersion.getIdentifier());

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/util/SourceFilesProviderProducerUtilTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/util/SourceFilesProviderProducerUtilTest.java
@@ -76,7 +76,7 @@ public class SourceFilesProviderProducerUtilTest {
         for (Path appResourcePath : appPaths.getResourcePaths()) {
             String fullWorkflowPath = appResourcePath.resolve(WORKFLOW_RELATIVE_PATH).toString();
             String calculatedRelativePath = getResourceRelativePath(context, new KieBuilderSetImpl.DummyResource(fullWorkflowPath));
-            assertThat(calculatedRelativePath).isEqualTo(WORKFLOW_RELATIVE_PATH);
+            assertThat(Path.of(calculatedRelativePath)).isEqualTo(Path.of(WORKFLOW_RELATIVE_PATH));
         }
     }
 


### PR DESCRIPTION
Fixing PredictionCodegenFactory class which was using File.separator matches against an instance of PortablePath. PortablePath though contains forward slashes `/` even on Windows, this such File.separator match fails there and results in error during code generation. (The only non-test fix in this PR).

Fixing several problems in tests causing failures in Windows:
* resource path has always forward slash `/` no need for `File.separator` in there. Replacing such File.separator references with plain `/` string/char.
* URL#getPath method returns resource path - not a valid path on Windows. Switching to Paths#get method signature that accepts URI parameter instead.
* flaky DeadlineHelperTest has perhaps a too strict check on expiration time, using `isAfter` assertion, which IMHO is susceptible to cases when the test is too fast (assumption). Adding a few millis to stabilize.
* replacing string comparison on paths with Path instances comparisons.