### PR TITLE
[NO_ISSUE] Avoid NPE if no user is provided to fetch task transitions

### DIFF
--- a/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/UserTaskServiceImpl.java
+++ b/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/UserTaskServiceImpl.java
@@ -93,7 +93,7 @@ public class UserTaskServiceImpl implements UserTaskService {
     @Override
     public List<UserTaskTransitionView> allowedTransitions(String taskId, IdentityProvider identity) {
         Optional<UserTaskInstance> userTaskInstance = application.get(UserTasks.class).instances().findById(taskId);
-        if (userTaskInstance.isEmpty()) {
+        if (userTaskInstance.isEmpty() || identity.getName() == null) {
             return Collections.emptyList();
         }
         UserTaskInstance ut = userTaskInstance.get();

--- a/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/lifecycle/DefaultUserTaskLifeCycle.java
+++ b/jbpm/jbpm-usertask/src/main/java/org/kie/kogito/usertask/impl/lifecycle/DefaultUserTaskLifeCycle.java
@@ -227,6 +227,10 @@ public class DefaultUserTaskLifeCycle implements UserTaskLifeCycle {
 
     private void checkPermission(UserTaskInstance userTaskInstance, String user, Collection<String> roles) {
 
+        if (user == null) {
+            throw new UserTaskInstanceNotAuthorizedException("No user defined to perform an operation on user task " + userTaskInstance.getId());
+        }
+
         if (WORKFLOW_ENGINE_USER.equals(user)) {
             return;
         }


### PR DESCRIPTION
This issue showed up when integrating an application into management console, and no user impersonation details were provided. Adding a simple guard to avoid the NPE.

