### PR TITLE
[incubator-kie-kogito-runtimes#4088] Force grpc-netty and grpc-netty-shaded versions and upgrade.

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -414,11 +414,6 @@
         <artifactId>grpc-netty-shaded</artifactId>
         <version>${version.io.grpc}</version>
       </dependency>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-netty</artifactId>
-        <version>${version.io.grpc}</version>
-      </dependency>
 
       <!-- code generation -->
       <dependency>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -98,7 +98,7 @@
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.18.1</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
     <version.io.vertx>4.5.18</version.io.vertx>
-    <version.io.grpc>1.69.1</version.io.grpc>
+    <version.io.grpc>1.75.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.20.2</version.io.quarkus.camel>
 
@@ -407,6 +407,16 @@
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-stub</artifactId>
+        <version>${version.io.grpc}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <version>${version.io.grpc}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
         <version>${version.io.grpc}</version>
       </dependency>
 


### PR DESCRIPTION
Resolves https://github.com/apache/incubator-kie-kogito-runtimes/issues/4088

The changes force a version of the libraries and updates the version of the libraries to the latest one. 