### PR TITLE
[incubator-kie-issues-2152] Use try with resources pattern in generated ProtostreamObjectMarshaller

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/persistence/ProtostreamObjectMarshallerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/persistence/ProtostreamObjectMarshallerJavaTemplate.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.codegen.process.persistence;
 
+import java.io.InputStream;
 import java.io.IOException;
 
 import org.infinispan.protostream.ProtobufUtil;


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2152

The generated code after this change looks like this:
```
    public ProtostreamObjectMarshaller() {
        context = new SerializationContextImpl(Configuration.builder().build());
        try (InputStream kogitotypesproto = getClass().getClassLoader().getResourceAsStream("META-INF/kogito-types.proto");
            InputStream applicationtypesproto = getClass().getClassLoader().getResourceAsStream("META-INF/application-types.proto")) {
            context.registerProtoFiles(((new org.infinispan.protostream.FileDescriptorSource()).addProtoFile("kogito-types.proto", kogitotypesproto)).addProtoFile("application-types.proto", applicationtypesproto));
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.StringProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.BooleanProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.DateProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.DoubleProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.FloatProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.IntegerProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.LongProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.InstantProtostreamBaseMarshaller());
            context.registerMarshaller(new org.jbpm.flow.serialization.marshaller.SerializableProtostreamBaseMarshaller());
            // (app specific marshallers)
        } catch (IOException e) {
            throw new java.io.UncheckedIOException(e);
        }
    }
```