### PR TITLE
[incubator-kie-issues-2093] remove forgotten reference to kie-addons-…

### DIFF
--- a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -225,19 +225,6 @@
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kie-addons-quarkus-messaging-deployment</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
       <artifactId>kie-addons-quarkus-monitoring-prometheus-deployment</artifactId>
       <version>${project.version}</version>
       <type>pom</type>


### PR DESCRIPTION
…quarkus-messaging-deployment

Follows-up on #4059 which removed artifact `org.kie:kie-addons-quarkus-messaging-deployment`, though by accident left its usage in one of integration tests that are part of the build reactor.

This problem was not apparent during PR check build as this was hidden by the fact that there was an older artifact downloaded from snapshots repository. The apparent failure would happen if the project version is changed, e.g. during a release build, then it would fail to locate the artifact and reactor build would fail.