### PR TITLE
[incubator-kie-issues#2149] Use system-default TransformerFactory instance

### DIFF
--- a/addons/common/process-svg/src/main/java/org/kie/kogito/svg/processor/AbstractSVGProcessor.java
+++ b/addons/common/process-svg/src/main/java/org/kie/kogito/svg/processor/AbstractSVGProcessor.java
@@ -40,7 +40,7 @@ public abstract class AbstractSVGProcessor implements SVGProcessor {
     protected Document svgDocument;
     protected SVGSummary summary = new SVGSummary();
     protected boolean mapById = true;
-    private TransformerFactory transformerFactory = TransformerFactory.newInstance();
+    private TransformerFactory transformerFactory = TransformerFactory.newDefaultInstance();
 
     public AbstractSVGProcessor(Document svgDocument, boolean mapById) {
         this.svgDocument = svgDocument;


### PR DESCRIPTION
Using the JDK built-in TransformerFactory instead of Saxon avoids issues when running in native mode:
```
java.lang.InstantiationException: net.sf.saxon.Configuration
	at java.base@23/java.lang.Class.newInstance(DynamicHub.java:798)
	at net.sf.saxon.Configuration.newConfiguration(Configuration.java:250)
	at net.sf.saxon.s9api.Processor.<init>(Processor.java:83)
	at net.sf.saxon.jaxp.SaxonTransformerFactory.<init>(SaxonTransformerFactory.java:59)
	at net.sf.saxon.TransformerFactoryImpl.<init>(TransformerFactoryImpl.java:42)
	at java.base@23/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
	at java.base@23/java.lang.reflect.Constructor.newInstance(Constructor.java:485)
	at java.base@23/java.util.ServiceLoader$ProviderImpl.newInstance(ServiceLoader.java:785)
	at java.base@23/java.util.ServiceLoader$ProviderImpl.get(ServiceLoader.java:725)
	at java.base@23/java.util.ServiceLoader$3.next(ServiceLoader.java:1397)
	at java.xml@23/javax.xml.transform.FactoryFinder$1.run(FactoryFinder.java:242)
	at java.base@23/java.security.AccessController.executePrivileged(AccessController.java:132)
	at java.base@23/java.security.AccessController.doPrivileged(AccessController.java:319)
	at java.xml@23/javax.xml.transform.FactoryFinder.findServiceProvider(FactoryFinder.java:237)
	at java.xml@23/javax.xml.transform.FactoryFinder.find(FactoryFinder.java:212)
	at java.xml@23/javax.xml.transform.TransformerFactory.newInstance(TransformerFactory.java:86)
	at org.kie.kogito.svg.processor.AbstractSVGProcessor.<init>(AbstractSVGProcessor.java:43)
	at org.kie.kogito.svg.processor.DefaultSVGProcessor.<init>(DefaultSVGProcessor.java:42)
```

