### PR TITLE
[incubator-kie-issues#2179] Failing async service task node pointing to wrong nodeInstanceId

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/AsyncEventNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/AsyncEventNodeInstance.java
@@ -37,6 +37,7 @@ import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.jobs.TimerDescription;
 import org.kie.kogito.jobs.descriptors.ProcessInstanceJobDescription;
 import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.ProcessInstanceExecutionException;
 import org.kie.kogito.services.uow.BaseWorkUnit;
 import org.kie.kogito.timer.TimerInstance;
 import org.kie.kogito.uow.WorkUnit;
@@ -194,5 +195,13 @@ public class AsyncEventNodeInstance extends EventNodeInstance {
         //trigger the actual node
         triggerNodeInstance((org.jbpm.workflow.instance.NodeInstance) actualInstance, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
         clearAsyncStatus();
+    }
+
+    @Override
+    protected void wrapException(ProcessInstanceExecutionException executionException) {
+        logger.debug("Exception already wrapped by node instance '{}' (node '{}' id: '{}') in process instance '{}' (process: '{}')... propagating exception.", getStringId(),
+                getNodeName(),
+                getNodeDefinitionId(), getProcessInstance().getId(), getProcessInstance().getProcessId());
+        throw executionException;
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -265,17 +265,23 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
                 captureError(e);
             } else {
                 // Checking if the exception has been already wrapped by the actual node instance to avoid unnecessary wrappings.
-                if (e instanceof ProcessInstanceExecutionException executionException && getId().equals(executionException.getFailedNodeInstanceId())) {
-                    logger.debug("Exception already wrapped by node instance '{}' (node '{}' id: '{}') in process instance '{}' (process: '{}')... propagating exception.", getStringId(),
-                            getNodeName(),
-                            getNodeDefinitionId(), processInstance.getId(), processInstance.getProcessId());
-                    throw executionException;
+                if (e instanceof ProcessInstanceExecutionException executionException) {
+                    wrapException(executionException);
                 }
                 logger.error("Error {} executing node instance '{}' (node '{}' id: '{}') in process instance '{}' (process: '{}') in a transactional environment (Wrapping)", e.getMessage(),
                         getStringId(), getNodeName(),
                         getNodeDefinitionId(), processInstance.getId(), processInstance.getProcessId());
                 throw new ProcessInstanceExecutionException(this.getProcessInstance().getId(), this.getNodeDefinitionId(), this.getId(), e.getMessage(), e);
             }
+        }
+    }
+
+    protected void wrapException(ProcessInstanceExecutionException executionException) {
+        if (getId().equals(executionException.getFailedNodeInstanceId())) {
+            logger.debug("Exception already wrapped by node instance '{}' (node '{}' id: '{}') in process instance '{}' (process: '{}')... propagating exception.", getStringId(),
+                    getNodeName(),
+                    getNodeDefinitionId(), processInstance.getId(), processInstance.getProcessId());
+            throw executionException;
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2179

If an async node instance fails in execution (Servicetask throwing an exception), leaves the process in error state as expected, but the error state both in the process instance state and Data Index refer to an unexisting node instance id.

We suspect that this is happening because when triggering an async node, process engine generates a virtual async node instance that wraps the async execution. Probably the error state refers to that AsyncEventNodeInstance

Ensemble:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4136
https://github.com/apache/incubator-kie-kogito-apps/pull/2283