### PR TITLE
NO-ISSUE: Fix UserTask exceptions management

### DIFF
--- a/quarkus/addons/rest-exception-handler/src/main/java/org/kie/kogito/resource/exceptions/UserTaskInstanceNotAuthorizedExceptionMapper.java
+++ b/quarkus/addons/rest-exception-handler/src/main/java/org/kie/kogito/resource/exceptions/UserTaskInstanceNotAuthorizedExceptionMapper.java
@@ -18,20 +18,20 @@
  */
 package org.kie.kogito.resource.exceptions;
 
-import org.kie.kogito.usertask.UserTaskInstanceNotFoundException;
+import org.kie.kogito.usertask.UserTaskInstanceNotAuthorizedException;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
 @Provider
-public class UserTaskInstanceNotAuthorizedExceptionMapper extends BaseExceptionMapper<UserTaskInstanceNotFoundException> {
+public class UserTaskInstanceNotAuthorizedExceptionMapper extends BaseExceptionMapper<UserTaskInstanceNotAuthorizedException> {
 
     @Inject
     ExceptionsHandler exceptionsHandler;
 
     @Override
-    public Response toResponse(UserTaskInstanceNotFoundException e) {
+    public Response toResponse(UserTaskInstanceNotAuthorizedException e) {
         return exceptionsHandler.mapException(e);
     }
 }

--- a/quarkus/addons/rest-exception-handler/src/main/java/org/kie/kogito/resource/exceptions/UserTaskInstanceNotFoundExceptionMapper.java
+++ b/quarkus/addons/rest-exception-handler/src/main/java/org/kie/kogito/resource/exceptions/UserTaskInstanceNotFoundExceptionMapper.java
@@ -18,20 +18,20 @@
  */
 package org.kie.kogito.resource.exceptions;
 
-import org.kie.kogito.usertask.UserTaskInstanceNotAuthorizedException;
+import org.kie.kogito.usertask.UserTaskInstanceNotFoundException;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
 @Provider
-public class UserTaskInstanceNotFoundExceptionMapper extends BaseExceptionMapper<UserTaskInstanceNotAuthorizedException> {
+public class UserTaskInstanceNotFoundExceptionMapper extends BaseExceptionMapper<UserTaskInstanceNotFoundException> {
 
     @Inject
     ExceptionsHandler exceptionsHandler;
 
     @Override
-    public Response toResponse(UserTaskInstanceNotAuthorizedException e) {
+    public Response toResponse(UserTaskInstanceNotFoundException e) {
         return exceptionsHandler.mapException(e);
     }
 }


### PR DESCRIPTION
This PR fixes a bug where two UserTask exception mapper classes had their exception types swapped. The mappers were handling the wrong exception types, which would have caused incorrect REST API responses for UserTask operations