### PR TITLE
[kie-issues#2217]Update Netty version from 4.1.128.Final to 4.1.129.Final

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -78,8 +78,8 @@
     <version.jakarta.annotation-api>2.1.1</version.jakarta.annotation-api>
     <version.jakarta.validation-api>3.0.2</version.jakarta.validation-api>
     <version.jakarta.xml.bind-api>4.0.4</version.jakarta.xml.bind-api>
+<version.io.netty>4.1.129.Final</version.io.netty>
 
-    <version.io.netty>4.1.128.Final</version.io.netty>
 
     <version.io.cloudevents>3.0.0</version.io.cloudevents>
     <!--


### PR DESCRIPTION
Updated Netty version from 4.1.128.Final to 4.1.129.Final
Closes https://github.com/apache/incubator-kie-issues/issues/2217

related PR: https://github.com/apache/incubator-kie-drools/pull/6558