### PR TITLE
[incubator-kie-issues#2229] Codegen refactoring to fix "Code too large" error for large projects

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/CodegenUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/CodegenUtils.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.codegen.core;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,5 +143,13 @@ public class CodegenUtils {
 
     public static boolean isObjectMapperField(FieldDeclaration fd) {
         return fd.getElementType().isClassOrInterfaceType() && fd.getElementType().asClassOrInterfaceType().getNameAsString().equals("ObjectMapper");
+    }
+
+    public static <T> List<List<T>> partitionList(List<T> list, int chunkSize) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += chunkSize) {
+            partitions.add(list.subList(i, Math.min(i + chunkSize, list.size())));
+        }
+        return partitions;
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -483,6 +483,13 @@ public class ProcessGenerator {
                 .addMember(createReadOnlyInstanceGenericWithWorkflowInstanceMethod(processInstanceFQCN))
                 .addMember(process(processMetaData));
 
+        processMetaData.getGeneratedClassModel()
+                .findAll(MethodDeclaration.class)
+                .stream()
+                .filter(m -> m.getNameAsString().startsWith("buildNodes_") ||
+                        m.getNameAsString().startsWith("buildConnections_"))
+                .forEach(cls::addMember);
+
         internalConfigure(processMetaData).ifPresent(cls::addMember);
         internalRegisterListeners(processMetaData).ifPresent(cls::addMember);
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerJavaTemplate.java
@@ -43,13 +43,12 @@ public class Processes implements org.kie.kogito.process.Processes {
     }
 
     public org.kie.kogito.process.Process<? extends org.kie.kogito.Model> processById(String processId) {
-        if ("$ProcessId".equals(processId)) {
-            return mappedProcesses.computeIfAbsent("$ProcessId", k -> new $ProcessClassName$(application).configure());
-        }
+        /* body provided during codegen */
         return null;
     }
 
     public java.util.Collection<String> processIds() {
-        return java.util.Arrays.asList("$ProcessId$");
+        /* body provided during codegen */
+        return null;
     }
 }


### PR DESCRIPTION
Refactors ProcessGenerator, ProcessVisitor, ProcessContainerGenerator and DecisionContainerGenerator to split large initialization blocks into smaller, chained methods.


Fixes: https://github.com/apache/incubator-kie-issues/issues/2229
