### PR TITLE
[incubatore-kie-issues#2246] Add gradle-examples to downstream build

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -88,6 +88,14 @@ Map getMultijobPRConfig(JenkinsFolder jobFolder) {
                 env : [
                     KOGITO_EXAMPLES_SUBFOLDER_POM: 'serverless-workflow-examples/',
                 ],
+            ],
+                [
+                id: 'kogito-gradle-examples',
+                repository: 'incubator-kie-kogito-examples',
+                dependsOn: 'kogito-apps',
+                env : [
+                    KOGITO_EXAMPLES_SUBFOLDER_POM: 'gradle-examples/',
+                ]
             ]
         ],
     ]

--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        job_name: [ kogito-apps, kogito-quarkus-examples, kogito-springboot-examples, serverless-workflow-examples ]
+        job_name: [ kogito-apps, kogito-quarkus-examples, kogito-springboot-examples, serverless-workflow-examples, kogito-gradle-examples ]
         os: [ubuntu-latest]
         java-version: [17]
         maven-version: ['3.9.11']
@@ -56,6 +56,9 @@ jobs:
           - job_name: serverless-workflow-examples
             repository: incubator-kie-kogito-examples
             env_KOGITO_EXAMPLES_SUBFOLDER_POM: serverless-workflow-examples/
+          - job_name: kogito-gradle-examples
+            repository: incubator-kie-kogito-examples
+            env_KOGITO_EXAMPLES_SUBFOLDER_POM: gradle-examples/
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.job_name }} (${{ matrix.os }} / Java-${{ matrix.java-version }} / Maven-${{ matrix.maven-version }})


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2246



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


