### PR TITLE
[issue-4206] Fix OpenTelemetry tests by setting otel.metrics.exporter to none

### DIFF
--- a/quarkus/addons/opentelemetry/integration-tests/src/test/java/org/kie/kogito/quarkus/serverless/workflow/opentelemetry/OtlpMockTestResource.java
+++ b/quarkus/addons/opentelemetry/integration-tests/src/test/java/org/kie/kogito/quarkus/serverless/workflow/opentelemetry/OtlpMockTestResource.java
@@ -54,6 +54,8 @@ public class OtlpMockTestResource implements QuarkusTestResourceLifecycleManager
         // Use HTTP/protobuf protocol (standard OTLP)
         config.put("quarkus.otel.exporter.otlp.protocol", "http/protobuf");
 
+        config.put("otel.metrics.exporter", "none");
+
         // Immediate export for testing (use simple span processor)
         config.put("quarkus.otel.traces.sampler", "always_on");
 


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/4206

