### PR TITLE
Fix CVE-2026-1002- Update vertx-core to 4.5.24

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -101,7 +101,7 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.3</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.5.23</version.io.vertx>
+    <version.io.vertx>4.5.24</version.io.vertx>
     <version.io.grpc>1.76.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.27.2</version.io.quarkus.camel>


### PR DESCRIPTION
Override vertx-core version from Quarkus BOM 3.27.2
Related PR-https://github.com/apache/incubator-kie-drools/pull/6636