### PR TITLE
[kogito-runtimes#4243] Do not use variable property value in GreetRestIT.

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/GreetRestIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/GreetRestIT.java
@@ -77,7 +77,7 @@ class GreetRestIT {
                 .then()
                 .statusCode(200)
                 .contentType(ContentType.HTML)
-                .body(containsString("SONATAFLOW WORKFLOW ENDPOINT"));
+                .body(containsString("<h4>SonataFlow Workflow Endpoint service is up and working!</h4>"));
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/apache/incubator-kie-kogito-runtimes/issues/4243

- Adds a non-changing value from the index.html webpage as a test value, instead of the value that can change. In addition it tests that the text contains html tag. 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


