### PR TITLE
[incubator-kie-issues#2164] Implement property retrieval from YAML files

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
@@ -21,7 +21,6 @@ package org.kie.kogito.codegen.api.context.impl;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +31,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.Predicate;
 
 import javax.lang.model.SourceVersion;
@@ -49,7 +47,8 @@ import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.utils.AddonsConfigDiscovery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
+
+import static org.drools.codegen.common.context.ModelBuildContextUtils.loadYmlProperties;
 
 public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
 
@@ -110,55 +109,6 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
         }
 
         return applicationProperties;
-    }
-
-    public static void loadYmlProperties(File ymlFile, Properties applicationProperties) {
-        Map<String, String> ymlMap = loadYmlStringMap(ymlFile);
-        if (ymlMap != null) {
-            applicationProperties.putAll(ymlMap);
-        }
-    }
-
-    protected static Map<String, String> loadYmlStringMap(File ymlFile) {
-        TreeMap<String, Object> ymlMap = loadYmlMap(ymlFile);
-        if (ymlMap != null) {
-            return convertYamlObjectToMap(ymlMap);
-        } else {
-            return null;
-        }
-    }
-
-    protected static TreeMap<String, Object> loadYmlMap(File ymlFile) {
-        if (ymlFile.exists() && ymlFile.isFile() && ymlFile.canRead()) {
-            Yaml yaml = new Yaml();
-            try (FileReader yamlFileReader = new FileReader(ymlFile, StandardCharsets.UTF_8)) {
-                return yaml.loadAs(yamlFileReader, TreeMap.class);
-            } catch (IOException e) {
-                LOGGER.debug("Unable to load '{}'.", ymlFile.getName(), e);
-            }
-        } else {
-            LOGGER.debug("Unable to load '{}'.", ymlFile.getName());
-        }
-        return null;
-    }
-
-    protected static Map<String, String> convertYamlObjectToMap(TreeMap<String, Object> toConvert) {
-        Map<String, String> toReturn = new HashMap<>();
-        convertYamlObjectToMap(toConvert, new StringBuilder(), toReturn);
-        return toReturn;
-    }
-
-    protected static void convertYamlObjectToMap(Map<String, Object> toRead, StringBuilder builder, Map<String, String> toPopulate) {
-        toRead.forEach((key, value) -> {
-            if (value instanceof Map) {
-                StringBuilder newBuilder = new StringBuilder(builder);
-                convertYamlObjectToMap((Map<String, Object>) value, newBuilder.append(key).append("."), toPopulate);
-            } else {
-                String property = builder.toString() + key;
-                String propertyValue = value != null ? value.toString() : "";
-                toPopulate.put(property, propertyValue);
-            }
-        });
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
@@ -112,7 +112,7 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
         return applicationProperties;
     }
 
-    protected static void loadYmlProperties(File ymlFile, Properties applicationProperties) {
+    public static void loadYmlProperties(File ymlFile, Properties applicationProperties) {
         Map<String, String> ymlMap = loadYmlStringMap(ymlFile);
         if (ymlMap != null) {
             applicationProperties.putAll(ymlMap);

--- a/kogito-codegen-modules/kogito-codegen-api/src/test/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContextTest.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/test/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContextTest.java
@@ -18,28 +18,16 @@
  */
 package org.kie.kogito.codegen.api.context.impl;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.Map;
 import java.util.Properties;
-import java.util.TreeMap;
 
-import org.drools.util.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.kogito.KogitoGAV;
 import org.kie.kogito.codegen.api.AddonsConfig;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YAML_FILE_NAME;
-import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YML_FILE_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AbstractKogitoBuildContextTest {
 
@@ -97,80 +85,6 @@ class AbstractKogitoBuildContextTest {
         assertThat(builder.build().getGAV()).isEmpty();
         assertThatThrownBy(() -> builder.withGAV(null)).isInstanceOf(NullPointerException.class).hasMessageContaining("gav");
         assertThat(builder.withGAV(KogitoGAV.EMPTY_GAV).build().getGAV()).hasValue(KogitoGAV.EMPTY_GAV);
-    }
-
-    @MethodSource("testData")
-    @ParameterizedTest
-    void loadYmlProperties(String fileName) {
-        File ymlFile = FileUtils.getFile(fileName);
-        assertTrue(ymlFile.exists());
-        Properties properties = new Properties();
-        AbstractKogitoBuildContext.loadYmlProperties(ymlFile, properties);
-        assertEquals("test", properties.getProperty("this.is.a"));
-        assertEquals("notNull", properties.getProperty("this.is.b"));
-        assertEquals("test", properties.getProperty("this.was.a"));
-        assertEquals("notNull", properties.getProperty("this.was.b"));
-        assertEquals("test", properties.getProperty("that.is.a"));
-        assertEquals("notNull", properties.getProperty("that.is.b"));
-        assertEquals("test", properties.getProperty("that.was.a"));
-        assertEquals("notNull", properties.getProperty("that.was.b"));
-    }
-
-    @MethodSource("testData")
-    @ParameterizedTest
-    void loadYmlStringMap(String fileName) {
-        File ymlFile = FileUtils.getFile(fileName);
-        assertTrue(ymlFile.exists());
-        Map<String, String> retrieved = AbstractKogitoBuildContext.loadYmlStringMap(ymlFile);
-        assertNotNull(retrieved);
-        commonCheck(retrieved);
-    }
-
-    @MethodSource("testData")
-    @ParameterizedTest
-    void loadYmlMap(String fileName) {
-        File ymlFile = FileUtils.getFile(fileName);
-        assertTrue(ymlFile.exists());
-        TreeMap<String, Object> retrieved = AbstractKogitoBuildContext.loadYmlMap(ymlFile);
-        assertNotNull(retrieved);
-        assertTrue(retrieved.containsKey("this"));
-    }
-
-    @MethodSource("testData")
-    @ParameterizedTest
-    void convertYamlObjectToMap(String fileName) {
-        File ymlFile = FileUtils.getFile(fileName);
-        assertTrue(ymlFile.exists());
-        TreeMap<String, Object> ymlMap = AbstractKogitoBuildContext.loadYmlMap(ymlFile);
-        assertNotNull(ymlMap);
-
-        Map<String, String> retrieved = AbstractKogitoBuildContext.convertYamlObjectToMap(ymlMap);
-        commonCheck(retrieved);
-    }
-
-    private static Collection<String> testData() {
-        return java.util.List.of(APPLICATION_PROPERTIES_YML_FILE_NAME, APPLICATION_PROPERTIES_YAML_FILE_NAME);
-    }
-
-    private void commonCheck(Map<String, String> retrieved) {
-        assertNotNull(retrieved);
-        assertTrue(retrieved.containsKey("this.is.a"));
-        assertEquals("test", retrieved.get("this.is.a"));
-        assertTrue(retrieved.containsKey("this.is.b"));
-        assertEquals("notNull", retrieved.get("this.is.b"));
-        assertTrue(retrieved.containsKey("this.was.a"));
-        assertEquals("test", retrieved.get("this.was.a"));
-        assertTrue(retrieved.containsKey("this.was.b"));
-        assertEquals("notNull", retrieved.get("this.was.b"));
-
-        assertTrue(retrieved.containsKey("that.is.a"));
-        assertEquals("test", retrieved.get("that.is.a"));
-        assertTrue(retrieved.containsKey("that.is.b"));
-        assertEquals("notNull", retrieved.get("that.is.b"));
-        assertTrue(retrieved.containsKey("that.was.a"));
-        assertEquals("test", retrieved.get("that.was.a"));
-        assertTrue(retrieved.containsKey("that.was.b"));
-        assertEquals("notNull", retrieved.get("that.was.b"));
     }
 
     static class MockKogitoBuildContext extends AbstractKogitoBuildContext {

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
@@ -18,30 +18,62 @@
  */
 package org.kie.kogito.quarkus.common.deployment;
 
+import java.io.File;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.StreamSupport;
+import java.util.Properties;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.kie.kogito.codegen.api.context.KogitoApplicationPropertyProvider;
 
-import static java.util.stream.Collectors.toSet;
+import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YAML_FILE_NAME;
+import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YML_FILE_NAME;
+import static org.kie.kogito.codegen.api.context.impl.AbstractKogitoBuildContext.loadYmlProperties;
+import static org.kie.kogito.internal.utils.ConversionUtils.convert;
 
 public class KogitoQuarkusApplicationPropertiesProvider implements KogitoApplicationPropertyProvider {
 
+    private final Properties properties;
+
+    public KogitoQuarkusApplicationPropertiesProvider() {
+        this.properties = new Properties();
+        Config config = ConfigProvider.getConfig();
+        config.getPropertyNames().forEach(property -> {
+            Optional<String> storedProperty = config.getOptionalValue(property, String.class);
+            if (storedProperty.isPresent()) {
+                this.properties.put(property, storedProperty.get());
+            } else {
+                this.properties.put(property, "");
+            }
+        });
+        URL ymlResource = Thread.currentThread().getContextClassLoader().getResource(APPLICATION_PROPERTIES_YML_FILE_NAME);
+        if (ymlResource != null) {
+            File ymlFile = new File(ymlResource.getFile());
+            loadYmlProperties(ymlFile, properties);
+        }
+        URL yamlResource = Thread.currentThread().getContextClassLoader().getResource(APPLICATION_PROPERTIES_YAML_FILE_NAME);
+        if (yamlResource != null) {
+            File yamlFile = new File(yamlResource.getFile());
+            loadYmlProperties(yamlFile, properties);
+        }
+
+    }
+
     @Override
     public Optional<String> getApplicationProperty(String property) {
-        return ConfigProvider.getConfig().getOptionalValue(property, String.class);
+        return Optional.ofNullable(properties.getProperty(property));
     }
 
     @Override
     public Collection<String> getApplicationProperties() {
-        return StreamSupport.stream(ConfigProvider.getConfig().getPropertyNames().spliterator(), false).collect(toSet());
+        return properties.stringPropertyNames();
     }
 
     @Override
     public <T> Optional<T> getApplicationProperty(String property, Class<T> clazz) {
-        return ConfigProvider.getConfig().getOptionalValue(property, clazz);
+        return Optional.ofNullable(convert(properties.getProperty(property), clazz));
     }
 
     @Override

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
@@ -79,10 +79,12 @@ public class KogitoQuarkusApplicationPropertiesProvider implements KogitoApplica
     @Override
     public void setApplicationProperty(String key, String value) {
         System.setProperty(key, value);
+        properties.put(key, value);
     }
 
     @Override
     public void removeApplicationProperty(String key) {
         System.clearProperty(key);
+        properties.remove(key);
     }
 }

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
@@ -18,19 +18,22 @@
  */
 package org.kie.kogito.quarkus.common.deployment;
 
-import java.io.File;
-import java.net.URL;
+import java.io.InputStream;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.kie.kogito.codegen.api.context.KogitoApplicationPropertyProvider;
 
 import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YAML_FILE_NAME;
 import static org.drools.codegen.common.DroolsModelBuildContext.APPLICATION_PROPERTIES_YML_FILE_NAME;
-import static org.kie.kogito.codegen.api.context.impl.AbstractKogitoBuildContext.loadYmlProperties;
+import static org.drools.codegen.common.context.ModelBuildContextUtils.loadYmlProperties;
 import static org.kie.kogito.internal.utils.ConversionUtils.convert;
 
 public class KogitoQuarkusApplicationPropertiesProvider implements KogitoApplicationPropertyProvider {
@@ -39,26 +42,29 @@ public class KogitoQuarkusApplicationPropertiesProvider implements KogitoApplica
 
     public KogitoQuarkusApplicationPropertiesProvider() {
         this.properties = new Properties();
-        Config config = ConfigProvider.getConfig();
-        config.getPropertyNames().forEach(property -> {
-            Optional<String> storedProperty = config.getOptionalValue(property, String.class);
-            if (storedProperty.isPresent()) {
-                this.properties.put(property, storedProperty.get());
-            } else {
-                this.properties.put(property, "");
+        try (InputStream ymlResourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(APPLICATION_PROPERTIES_YML_FILE_NAME)) {
+            if (ymlResourceStream != null) {
+                loadYmlProperties(ymlResourceStream, properties);
             }
-        });
-        URL ymlResource = Thread.currentThread().getContextClassLoader().getResource(APPLICATION_PROPERTIES_YML_FILE_NAME);
-        if (ymlResource != null) {
-            File ymlFile = new File(ymlResource.getFile());
-            loadYmlProperties(ymlFile, properties);
+        } catch (Exception e) {
+            // Ignore exception and continue loading properties from yaml file if present
         }
-        URL yamlResource = Thread.currentThread().getContextClassLoader().getResource(APPLICATION_PROPERTIES_YAML_FILE_NAME);
-        if (yamlResource != null) {
-            File yamlFile = new File(yamlResource.getFile());
-            loadYmlProperties(yamlFile, properties);
+        try (InputStream yamlResourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(APPLICATION_PROPERTIES_YAML_FILE_NAME)) {
+            if (yamlResourceStream != null) {
+                loadYmlProperties(yamlResourceStream, properties);
+            }
+        } catch (Exception e) {
+            // Ignore exception and continue loading properties from microprofile config
         }
-
+        Config config = ConfigProvider.getConfig();
+        // This is needed to preserve the correct property override order
+        List<ConfigSource> sortedSources = StreamSupport.stream(config.getConfigSources().spliterator(), false).sorted(new ConfigSourceSorted()).toList();
+        sortedSources.forEach(configSource -> configSource.getPropertyNames().forEach(property -> {
+            String value = configSource.getValue(property);
+            if (value != null) {
+                this.properties.put(property, value);
+            }
+        }));
     }
 
     @Override
@@ -86,5 +92,13 @@ public class KogitoQuarkusApplicationPropertiesProvider implements KogitoApplica
     public void removeApplicationProperty(String key) {
         System.clearProperty(key);
         properties.remove(key);
+    }
+
+    private static final class ConfigSourceSorted implements Comparator<ConfigSource> {
+
+        @Override
+        public int compare(ConfigSource o1, ConfigSource o2) {
+            return Integer.compare(o1.getOrdinal(), o2.getOrdinal());
+        }
     }
 }

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/test/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProviderTest.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/test/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProviderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.quarkus.common.deployment;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KogitoQuarkusApplicationPropertiesProviderTest {
+
+    private KogitoQuarkusApplicationPropertiesProvider provider;
+
+    private static final Map<String, String> DEFAULT_PROPERTIES = Map.of("this.is.a", "test",
+            "this.is.b", "notNull",
+            "this.was.a", "test",
+            "this.was.b", "notNull",
+            "that.is.a", "test",
+            "that.is.b", "notNull",
+            "that.was.a", "test",
+            "that.was.b", "notNull");
+
+    @BeforeEach
+    public void setUp() {
+        provider = new KogitoQuarkusApplicationPropertiesProvider();
+    }
+
+    @Test
+    void getApplicationProperty() {
+        DEFAULT_PROPERTIES.forEach((key, value) -> assertEquals(value, provider.getApplicationProperty(key).orElse(null)));
+    }
+
+    @Test
+    void getApplicationPropertyOverride() {
+        DEFAULT_PROPERTIES.keySet().forEach(key -> System.setProperty(key, "overridden"));
+        KogitoQuarkusApplicationPropertiesProvider providerWithOverrides = new KogitoQuarkusApplicationPropertiesProvider();
+        DEFAULT_PROPERTIES.keySet().forEach(key -> assertEquals("overridden", providerWithOverrides.getApplicationProperty(key).orElse(null)));
+        DEFAULT_PROPERTIES.keySet().forEach(System::clearProperty);
+    }
+
+    @Test
+    void getApplicationProperties() {
+        Collection<String> retrieved = provider.getApplicationProperties();
+        DEFAULT_PROPERTIES.forEach((key, value) -> assertTrue(retrieved.contains(key)));
+    }
+
+    @Test
+    void testGetApplicationProperty() {
+        DEFAULT_PROPERTIES.forEach((key, value) -> assertEquals(value, provider.getApplicationProperty(key, String.class).orElse(null)));
+    }
+
+    @Test
+    void setApplicationProperty() {
+        provider.setApplicationProperty("test.key", "test.value");
+        assertEquals("test.value", provider.getApplicationProperty("test.key").orElse(null));
+    }
+
+    @Test
+    void removeApplicationProperty() {
+        provider.setApplicationProperty("test.key", "test.value");
+        assertTrue(provider.getApplicationProperties().contains("test.key"));
+        provider.removeApplicationProperty("test.key");
+        assertFalse(provider.getApplicationProperties().contains("test.key"));
+    }
+
+}

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/test/resources/application.yaml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/test/resources/application.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+this:
+  is:
+    a: test
+    b: notNull
+  was:
+    a: test
+    b: notNull
+
+that:
+  is:
+    a: test
+    b: notNull
+  was:
+    a: test
+    b: notNull


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2164

Depends on:
https://github.com/apache/incubator-kie-drools/pull/6674

Needed by:
https://github.com/apache/incubator-kie-kogito-examples/pull/2206

This PR:

1. modify property retrieval for quarkus environment
2. add properties retrieved from yaml files to the one discovered by previous approach



<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


