### PR TITLE
Upgrade Quarkus to 3.27.3 and vertx-core to 4.5.25 to mitigate CVE-2026-33870, CVE-2026-33871 (netty-codec-http-4.1.131.Final)

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -40,7 +40,7 @@
     <!-- End of various transitive overrides. -->
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>3.27.2</version.io.quarkus>
+    <version.io.quarkus>3.27.3</version.io.quarkus>
     <version.io.quarkus.quarkus-test>${version.io.quarkus}</version.io.quarkus.quarkus-test>
     <version.org.springframework>6.2.17</version.org.springframework>
     <version.org.springframework.boot>3.5.10</version.org.springframework.boot>
@@ -101,10 +101,10 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.3</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.5.24</version.io.vertx>
+    <version.io.vertx>4.5.25</version.io.vertx>
     <version.io.grpc>1.76.0</version.io.grpc>
 
-    <version.io.quarkus.camel>3.27.2</version.io.quarkus.camel>
+    <version.io.quarkus.camel>3.27.3</version.io.quarkus.camel>
 
     <version.io.swagger.parser.v3>2.1.34</version.io.swagger.parser.v3>
     <version.io.swagger.core.v3>2.2.38</version.io.swagger.core.v3>

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Internal BOM descriptor for Kogito modules targeting Quarkus use-cases. Specific dependencies targeting the Quarkus platform must be added here.</description>
 
   <properties>
-    <!-- Keep it aligned with https://github.com/quarkusio/quarkus/blob/3.27.2/pom.xml#L72 -->
+    <!-- Keep it aligned with https://github.com/quarkusio/quarkus/blob/3.27.3/pom.xml#L72 -->
     <version.io.fabric8.kubernetes-client>7.3.1</version.io.fabric8.kubernetes-client>
   </properties>
 


### PR DESCRIPTION
Upgrade Quarkus to 3.27.3 and vertx-core to 4.5.25 to mitigate CVE-2026-33870, CVE-2026-33871 (netty-codec-http-4.1.131.Final)

Related PR
Drools:  https://github.com/apache/incubator-kie-drools/pull/6673
optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3218