### PR TITLE
[no_issue_logs] Retrieve invoker and reproducible logs for better debugging

### DIFF
--- a/.github/workflows/pr-kogito-runtimes.yml
+++ b/.github/workflows/pr-kogito-runtimes.yml
@@ -79,3 +79,17 @@ jobs:
         with:
           name: dependency-trees-logs_kogito-runtimes_${{ matrix.os }}
           path: '**/${{ env.DEPENDENCY_TREE_FILE }}'
+      - name: Upload Build logs
+        uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: build-logs_${{ matrix.job_name }}_${{ matrix.os }}
+          path: '**/build.log'
+      - name: Upload Build Compare
+        uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: build-compare_${{ matrix.job_name }}_${{ matrix.os }}
+          path: |
+            **/*.buildcompare
+            **/*.buildinfo


### PR DESCRIPTION
Add two more GHA tasks to retrieve build.logs (generated by maven invoker) and buildcompare/buildinfo (generated by reproducible check)

With that in place, after the build, there will be two new task from which it would be possible to downlaod the zipped artifacts of the above files

Companion of:
https://github.com/apache/incubator-kie-drools/pull/6690
https://github.com/apache/incubator-kie-kogito-apps/pull/2329

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


