### PR TITLE
kie-issues#2285: Restore `kie-addons-kubernetes-service-catalog` module

### DIFF
--- a/addons/common/kubernetes-service-catalog/pom.xml
+++ b/addons/common/kubernetes-service-catalog/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kogito-addons-common-parent</artifactId>
+        <groupId>org.kie</groupId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kie-addons-kubernetes-service-catalog</artifactId>
+    <name>KIE :: Add-Ons :: Kubernetes Service Catalog</name>
+    <description>Common Library for Kubernetes Service Discovery implementations</description>
+
+  <properties>
+    <java.module.name>org.kie.kogito.addons.k8s.resource.catalog</java.module.name>
+  </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/DefaultKubernetesServiceCatalog.java
+++ b/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/DefaultKubernetesServiceCatalog.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+import java.net.URI;
+import java.util.Optional;
+
+final class DefaultKubernetesServiceCatalog implements KubernetesServiceCatalog {
+
+    @Override
+    public Optional<URI> getServiceAddress(KubernetesServiceCatalogKey key) {
+        throw new UnsupportedOperationException("You need to define a " + KubernetesServiceCatalog.class.getSimpleName() + " implementation");
+    }
+}

--- a/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/DefaultKubernetesServiceCatalogFactory.java
+++ b/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/DefaultKubernetesServiceCatalogFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+public final class DefaultKubernetesServiceCatalogFactory {
+
+    private DefaultKubernetesServiceCatalogFactory() {
+    }
+
+    public static KubernetesServiceCatalog createKubernetesServiceCatalog() {
+        return new DefaultKubernetesServiceCatalog();
+    }
+}

--- a/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesProtocol.java
+++ b/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesProtocol.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+public enum KubernetesProtocol {
+
+    KUBERNETES("kubernetes"),
+    OPENSHIFT("openshift"),
+    KNATIVE("knative");
+
+    private final String value;
+
+    KubernetesProtocol(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static KubernetesProtocol from(String value) {
+        switch (value) {
+            case "kubernetes":
+                return KUBERNETES;
+            case "openshift":
+                return OPENSHIFT;
+            case "knative":
+                return KNATIVE;
+            default:
+                throw new IllegalArgumentException("The provided protocol [" + value + "] is not " +
+                        "supported, supported values are 'kubernetes', 'openshift', and 'knative'");
+        }
+    }
+}

--- a/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalog.java
+++ b/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalog.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+import java.net.URI;
+import java.util.Optional;
+
+public interface KubernetesServiceCatalog {
+
+    Optional<URI> getServiceAddress(KubernetesServiceCatalogKey key);
+}

--- a/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogKey.java
+++ b/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogKey.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+import java.util.Objects;
+
+public final class KubernetesServiceCatalogKey {
+
+    private final KubernetesProtocol protocol;
+
+    private final String coordinates;
+
+    public KubernetesServiceCatalogKey(KubernetesProtocol protocol, String coordinates) {
+        this.protocol = protocol;
+        this.coordinates = coordinates;
+    }
+
+    public KubernetesProtocol getProtocol() {
+        return protocol;
+    }
+
+    public String getCoordinates() {
+        return coordinates;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KubernetesServiceCatalogKey that = (KubernetesServiceCatalogKey) o;
+        return protocol == that.protocol && Objects.equals(coordinates, that.coordinates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(protocol, coordinates);
+    }
+}

--- a/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogProvider.java
+++ b/addons/common/kubernetes-service-catalog/src/main/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+public interface KubernetesServiceCatalogProvider {
+
+    KubernetesServiceCatalog create();
+}

--- a/addons/common/kubernetes-service-catalog/src/test/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogTest.java
+++ b/addons/common/kubernetes-service-catalog/src/test/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.addons.k8s.resource.catalog.KubernetesProtocol.KNATIVE;
+import static org.kie.kogito.addons.k8s.resource.catalog.KubernetesProtocol.KUBERNETES;
+import static org.kie.kogito.addons.k8s.resource.catalog.KubernetesProtocol.OPENSHIFT;
+
+/**
+ * Test classes for implementations of {@link KubernetesServiceCatalog} must extend this class.
+ * It tests all use cases an implementation of {@link KubernetesServiceCatalog} must cover.
+ */
+public abstract class KubernetesServiceCatalogTest {
+
+    private static final String EXPECTED_KNATIVE_URI = "http://serverless-workflow-greeting-quarkus.default.10.99.154.147.sslip.io";
+
+    private static final String EXPECTED_KUBERNETES_URI = "http://serverless-workflow-greeting-quarkus-kubernetes.default.10.99.154.147.sslip.io";
+
+    private static final String EXPECTED_OPENSHIFT_URI = "http://serverless-workflow-greeting-quarkus-openshift.default.10.99.154.147.sslip.io";
+
+    private static final String NAMESPACE = "default";
+
+    private static final String KNATIVE_SERVICENAME = "serverless-workflow-greeting-quarkus";
+
+    private static final String KUBERNETES_SERVICENAME = "serverless-workflow-greeting-quarkus-kubernetes";
+
+    private static final String OPENSHIFT_SERVICENAME = "serverless-workflow-greeting-quarkus-openshift";
+
+    private static final String NAMESPACE_KNATIVE_SERVICENAME = NAMESPACE + '/' + KNATIVE_SERVICENAME;
+
+    private static final String NAMESPACE_KUBERNETES_SERVICENAME = NAMESPACE + '/' + KUBERNETES_SERVICENAME;
+
+    private static final String NAMESPACE_OPENSHIFT_SERVICENAME = NAMESPACE + '/' + OPENSHIFT_SERVICENAME;
+
+    private static final String GVK = "services.v1.serving.knative.dev";
+
+    private static final String GVK_KNATIVE_SERVICENAME = GVK + '/' + KNATIVE_SERVICENAME;
+
+    private static final String GVK_NAMESPACE_SERVICENAME = GVK + '/' + NAMESPACE_KNATIVE_SERVICENAME;
+
+    private static final String GVK_KUBERNETES_SERVICENAME = GVK + '/' + KUBERNETES_SERVICENAME;
+
+    private static final String GVK_NAMESPACE_KUBERNETES_SERVICENAME = GVK + '/' + NAMESPACE_KUBERNETES_SERVICENAME;
+
+    private static final String GVK_OPENSHIFT_SERVICENAME = GVK + '/' + OPENSHIFT_SERVICENAME;
+
+    private static final String GVK_NAMESPACE_OPENSHIFT_SERVICENAME = GVK + '/' + NAMESPACE_OPENSHIFT_SERVICENAME;
+
+    private final KubernetesServiceCatalog kubernetesServiceCatalog;
+
+    protected KubernetesServiceCatalogTest(KubernetesServiceCatalog kubernetesServiceCatalog) {
+        this.kubernetesServiceCatalog = kubernetesServiceCatalog;
+    }
+
+    protected final String getNamespace() {
+        return NAMESPACE;
+    }
+
+    protected final String getKnativeServiceName() {
+        return KNATIVE_SERVICENAME;
+    }
+
+    protected final String getKubernetesServiceName() {
+        return KUBERNETES_SERVICENAME;
+    }
+
+    protected final String getOpenshiftServicename() {
+        return OPENSHIFT_SERVICENAME;
+    }
+
+    @ParameterizedTest
+    @MethodSource("possibleUriFormats")
+    void getServiceAddress(KubernetesProtocol kubernetesProtocol, String coordinates, String expectedUri) {
+        KubernetesServiceCatalogKey key = new KubernetesServiceCatalogKey(kubernetesProtocol, coordinates);
+        assertThat(kubernetesServiceCatalog.getServiceAddress(key))
+                .map(URI::toString)
+                .hasValue(expectedUri);
+    }
+
+    protected static Stream<Arguments> possibleUriFormats() {
+        return Stream.of(
+                Arguments.of(KNATIVE, KNATIVE_SERVICENAME, EXPECTED_KNATIVE_URI),
+                Arguments.of(KNATIVE, NAMESPACE_KNATIVE_SERVICENAME, EXPECTED_KNATIVE_URI),
+                Arguments.of(KNATIVE, GVK_KNATIVE_SERVICENAME, EXPECTED_KNATIVE_URI),
+                Arguments.of(KNATIVE, GVK_NAMESPACE_SERVICENAME, EXPECTED_KNATIVE_URI),
+
+                Arguments.of(KUBERNETES, GVK_KUBERNETES_SERVICENAME, EXPECTED_KUBERNETES_URI),
+                Arguments.of(KUBERNETES, GVK_NAMESPACE_KUBERNETES_SERVICENAME, EXPECTED_KUBERNETES_URI),
+
+                Arguments.of(OPENSHIFT, GVK_OPENSHIFT_SERVICENAME, EXPECTED_OPENSHIFT_URI),
+                Arguments.of(OPENSHIFT, GVK_NAMESPACE_OPENSHIFT_SERVICENAME, EXPECTED_OPENSHIFT_URI));
+    }
+}

--- a/addons/common/pom.xml
+++ b/addons/common/pom.xml
@@ -45,6 +45,7 @@
     <module>process-dynamic</module>
     <module>knative</module>
     <module>kubernetes</module>
+    <module>kubernetes-service-catalog</module>
     <module>jobs</module>
     <module>events</module>
     <module>monitoring</module>


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/2285

The `kie-addons-kubernetes-service-catalog` module was unintentionally removed in 46eecbac26 together with the Serverless Workflow modules, but it is still referenced by other modules in this repository (e.g. kogito-bom and quarkus/addons/kubernetes/runtime).

This PR restores it from 3ce1f258edb57723bd937f8d13d4b7292eb56dd2.
