### PR TITLE
[kie-issues#2306] Update Spring dependencies to 6.2.18 and Spring Boot to 3.5.14

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -42,8 +42,8 @@
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>3.27.3</version.io.quarkus>
     <version.io.quarkus.quarkus-test>${version.io.quarkus}</version.io.quarkus.quarkus-test>
-    <version.org.springframework>6.2.17</version.org.springframework>
-    <version.org.springframework.boot>3.5.12</version.org.springframework.boot>
+    <version.org.springframework>6.2.18</version.org.springframework>
+    <version.org.springframework.boot>3.5.14</version.org.springframework.boot>
     <version.org.apache.kafka>4.1.2</version.org.apache.kafka>
 
     <version.org.bouncycastle.bc.jdk18on>1.84</version.org.bouncycastle.bc.jdk18on>

--- a/kogito-gradle-plugin-test/gradle.properties
+++ b/kogito-gradle-plugin-test/gradle.properties
@@ -19,6 +19,6 @@
 #
 #Gradle properties
 
-springBootVersion=3.5.12
+springBootVersion=3.5.14
 taskTreeVersion=4.0.1
 kogitoVersion=999-SNAPSHOT


### PR DESCRIPTION
New vulnerabilities have been identified in Spring Boot and the Spring Framework. To address these issues, the following dependency updates are required:
Changes
Spring Framework: 6.2.17 → 6.2.18
Spring Boot: 3.5.12 → 3.5.14
These updates include fixes for the latest reported security vulnerabilities.

Related PR:
https://github.com/apache/incubator-kie-optaplanner/pull/3222
https://github.com/apache/incubator-kie-kogito-examples/pull/2211