### PR TITLE
[DO-NOT-MERGE] [incubator-kie-drools-6576] Native Java Compiler as default instead o…

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ImportClassTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/ImportClassTest.java
@@ -28,7 +28,8 @@ public class ImportClassTest extends JbpmBpmn2TestCase {
     public void testResourceType() {
         assertThatExceptionOfType(RuntimeException.class)
                 .isThrownBy(() -> createKogitoProcessRuntime("build/sample.bpmn", "build/sample2.bpmn"))
-                .withMessageContaining("Process Compilation error HelloService cannot be resolved to a type");
+                .withMessageContaining("Process Compilation error")
+                .withMessageContaining("HelloService");
     }
 
 }


### PR DESCRIPTION
…f ecj

- Issue: https://github.com/apache/incubator-kie-drools/issues/6576

- Cross-repo PR : https://github.com/apache/incubator-kie-drools/pull/6587

---
- This kogito-runtimes PR only fixes test assertion not to depend on ecj error message
- If we set `-Ddrools.dialect.java.compiler=ECLIPSE` for kogito application:
    - Switches BPMN-script and rule compilation back to ECJ.
    - Does not switch the kogito-maven-plugin's generated-sources compilation back to ECJ.
    - So a kogito project cannot uniformly opt back to ECJ. The kogito-maven-plugin path will always use Native compiler. This is pre-existing, not introduced by this PR.
-  In other words, this drools PR makes uniformly Native compiler as default from Native compiler + ECJ mix.