### PR TITLE
kie-issues#2285: Remove references to kogito-jsonpath-expression and kogito-jq-expression modules

### DIFF
--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -2162,28 +2162,6 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-jsonpath-expression</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-jsonpath-expression</artifactId>
-        <version>${project.version}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-jq-expression</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-jq-expression</artifactId>
-        <version>${project.version}</version>
-        <classifier>sources</classifier>
-      </dependency>
 
 			<!-- spring boot starter -->
       <dependency>

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
@@ -99,18 +99,6 @@
 
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-jsonpath-expression</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-jq-expression</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/2285

The `kogito-jsonpath-expression` and `kogito-jq-expression` modules were removed in [46eecbac26](https://github.com/apache/incubator-kie-kogito-runtimes/commit/46eecbac26f7c1989652f92560836ffce4a7e341) together with the Serverless Workflow modules, but some references remained in other modules in this repository (e.g. kogito-bom and kogito-codegen-modules/kogito-codegen-processes-integration-tests).

This PR removes them from those POMs as they were not being used.
