### PR TITLE
 Upgrade Netty to 4.1.133.Final and Vert.x Core to 4.5.27 to address security vulnerabilities

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -80,7 +80,7 @@
     <version.jakarta.validation-api>3.1.1</version.jakarta.validation-api>
     <version.jakarta.xml.bind-api>4.0.4</version.jakarta.xml.bind-api>
 
-    <version.io.netty>4.1.132.Final</version.io.netty>
+    <version.io.netty>4.1.133.Final</version.io.netty>
 
     <version.io.cloudevents>3.0.0</version.io.cloudevents>
     <!--
@@ -101,7 +101,7 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.3</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.5.25</version.io.vertx>
+    <version.io.vertx>4.5.27</version.io.vertx>
     <version.io.grpc>1.76.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.27.3</version.io.quarkus.camel>


### PR DESCRIPTION
 Upgrade Netty to 4.1.133.Final and Vert.x Core to 4.5.27 to address security vulnerabilities