### PR TITLE
NO-ISSUE: Remove `kie-addons-quarkus-process-definitions` from kogito-bom

### DIFF
--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -1199,28 +1199,6 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-addons-quarkus-process-definitions</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-addons-quarkus-process-definitions</artifactId>
-        <version>${project.version}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-addons-quarkus-process-definitions-deployment</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-addons-quarkus-process-definitions-deployment</artifactId>
-        <version>${project.version}</version>
-        <classifier>sources</classifier>
-      </dependency>
 
       <dependency>
         <groupId>org.kie</groupId>


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/2285

Similar to https://github.com/apache/incubator-kie-kogito-runtimes/pull/4286, the `kie-addons-quarkus-process-definitions` module was deleted, but not removed from the kogito-bom.