### PR TITLE
NO-ISSUE: Add vertx-core to dependency management to address security vulnerability

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -1176,6 +1176,13 @@
       </dependency>
 
       <!-- Vertx libraries, including PostgreSQL client -->
+
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-core</artifactId>
+        <version>${version.io.vertx}</version>
+      </dependency>
+
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-pg-client</artifactId>


### PR DESCRIPTION
Add vertx-core to dependency management to address security vulnerability