### PR TITLE
[incubator_kie_issue_#2317] Code generation fails for Task Name containing hyphen

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/UserTaskSpecialCharsIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/UserTaskSpecialCharsIT.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.codegen.process;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.Application;
+import org.kie.kogito.Model;
+import org.kie.kogito.codegen.AbstractCodegenIT;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.Processes;
+import org.kie.kogito.process.WorkItem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserTaskSpecialCharsIT extends AbstractCodegenIT {
+
+    @Test
+    public void testUserTaskNamesWithSpecialCharactersCompileSuccessfully() throws Exception {
+        // Generate code from BPMN with user tasks containing special characters:
+        Application app = generateCodeProcessesOnly("usertask/UserTasksWithSpecialChars.bpmn2");
+
+        assertThat(app).isNotNull();
+
+        // Verify the process was generated and can be retrieved
+        Process<? extends Model> process = app.get(Processes.class).processById("UserTasksWithSpecialChars");
+        assertThat(process)
+                .as("Process should be generated and accessible")
+                .isNotNull();
+
+        assertThat(process.id())
+                .as("Process ID should match")
+                .isEqualTo("UserTasksWithSpecialChars");
+    }
+
+    @Test
+    public void testProcessWithSpecialCharTaskNamesCanBeInstantiated() throws Exception {
+        Application app = generateCodeProcessesOnly("usertask/UserTasksWithSpecialChars.bpmn2");
+        assertThat(app).isNotNull();
+
+        Process<? extends Model> process = app.get(Processes.class).processById("UserTasksWithSpecialChars");
+
+        // Create a process instance
+        Model model = process.createModel();
+        ProcessInstance<?> processInstance = process.createInstance(model);
+
+        assertThat(processInstance)
+                .as("Process instance should be created successfully")
+                .isNotNull();
+
+        // Start the process
+        processInstance.start();
+
+        assertThat(processInstance.status())
+                .as("Process should be active after start")
+                .isEqualTo(ProcessInstance.STATE_ACTIVE);
+
+        // Verify that user tasks are accessible
+        assertThat(processInstance.workItems())
+                .as("Process should have user tasks waiting")
+                .isNotEmpty();
+
+        WorkItem workItem = processInstance.workItems().iterator().next();
+        assertThat(workItem)
+                .as("Work item should be accessible")
+                .isNotNull();
+
+        // The work item name should be one of our tasks with special characters
+        assertThat(workItem.getName())
+                .as("Work item should have a valid name")
+                .isIn("HR-Interview", "Technical-Review", "Final.Approval", "Manager@Approval");
+    }
+
+    @Test
+    public void testUserTasksWithSpecialCharsCanBeCompleted() throws Exception {
+        Application app = generateCodeProcessesOnly("usertask/UserTasksWithSpecialChars.bpmn2");
+        assertThat(app).isNotNull();
+
+        Process<? extends Model> process = app.get(Processes.class).processById("UserTasksWithSpecialChars");
+        Model model = process.createModel();
+        ProcessInstance<?> processInstance = process.createInstance(model);
+        processInstance.start();
+
+        // Get the first user task
+        WorkItem workItem = processInstance.workItems().iterator().next();
+        String workItemId = workItem.getId();
+
+        // Complete the work item - this internally uses the generated signal methods
+        processInstance.completeWorkItem(workItemId, Collections.emptyMap());
+
+        // Verify the work item was completed successfully
+        assertThat(processInstance.status())
+                .as("Process should still be active or completed")
+                .isIn(ProcessInstance.STATE_ACTIVE, ProcessInstance.STATE_COMPLETED);
+    }
+
+    @Test
+    public void testGeneratedProcessClassHasSanitizedMethodNames() throws Exception {
+        // Generate application
+        Application app = generateCodeProcessesOnly("usertask/UserTasksWithSpecialChars.bpmn2");
+        assertThat(app).isNotNull();
+
+        // Load the main Process class which contains all the methods for the 4 user tasks
+        ClassLoader classLoader = testClassLoader();
+        Class<?> processClass = classLoader.loadClass("org.kie.kogito.test.UserTasksWithSpecialCharsProcess");
+
+        assertThat(processClass)
+                .as("Process class should be generated")
+                .isNotNull();
+
+        // Get ALL method names from the Process class
+        java.util.List<String> methodNames = java.util.Arrays.stream(processClass.getDeclaredMethods())
+                .map(java.lang.reflect.Method::getName)
+                .collect(java.util.stream.Collectors.toList());
+
+        assertThat(methodNames)
+                .as("Process class should have methods")
+                .isNotEmpty();
+
+        // Verify that ALL method names are valid Java identifiers (no special characters)
+        for (String methodName : methodNames) {
+            assertThat(methodName)
+                    .as("Method name '%s' should not contain hyphens", methodName)
+                    .doesNotContain("-");
+
+            assertThat(methodName)
+                    .as("Method name '%s' should not contain dots", methodName)
+                    .doesNotContain(".");
+
+            assertThat(methodName)
+                    .as("Method name '%s' should not contain @ symbols", methodName)
+                    .doesNotContain("@");
+
+            assertThat(methodName)
+                    .as("Method name '%s' should not contain spaces", methodName)
+                    .doesNotContain(" ");
+        }
+
+    }
+
+}

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/usertask/UserTasksWithSpecialChars.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/usertask/UserTasksWithSpecialChars.bpmn2
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:process id="UserTasksWithSpecialChars" tns:packageName="org.kie.kogito.test" name="UserTasksWithSpecialChars" isExecutable="true" processType="Public">
+    <bpmn2:startEvent id="StartEvent_1" name="StartProcess">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[StartProcess]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="UserTask_1" name="HR-Interview">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[HR-Interview]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_1">
+        <bpmn2:dataInput id="DataInput_1" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:inputSet id="_InputSet_1">
+          <bpmn2:dataInputRefs>DataInput_1</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_1" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_1">
+        <bpmn2:targetRef>DataInput_1</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_1">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_1">HR-Interview</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_2">DataInput_1</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" tns:priority="1" sourceRef="StartEvent_1" targetRef="UserTask_1"/>
+    <bpmn2:userTask id="UserTask_2" name="Technical-Review">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Technical-Review]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_2">
+        <bpmn2:dataInput id="DataInput_2" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:inputSet id="_InputSet_2">
+          <bpmn2:dataInputRefs>DataInput_2</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_2" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_2">
+        <bpmn2:targetRef>DataInput_2</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_2">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_3">Technical-Review</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_4">DataInput_2</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" sourceRef="UserTask_1" targetRef="UserTask_2"/>
+    <bpmn2:userTask id="UserTask_3" name="Final.Approval">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Final.Approval]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_3">
+        <bpmn2:dataInput id="DataInput_3" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:inputSet id="_InputSet_3">
+          <bpmn2:dataInputRefs>DataInput_3</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_3" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_3">
+        <bpmn2:targetRef>DataInput_3</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_3">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_5">Final.Approval</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_6">DataInput_3</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" tns:priority="1" sourceRef="UserTask_2" targetRef="UserTask_3"/>
+    <bpmn2:userTask id="UserTask_4" name="Manager@Approval">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Manager@Approval]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_4">
+        <bpmn2:dataInput id="DataInput_4" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:inputSet id="_InputSet_4">
+          <bpmn2:dataInputRefs>DataInput_4</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_4" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_4">
+        <bpmn2:targetRef>DataInput_4</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_4">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_7">Manager@Approval</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_8">DataInput_4</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_4" tns:priority="1" sourceRef="UserTask_3" targetRef="UserTask_4"/>
+    <bpmn2:userTask id="UserTask_5" name="Final Decision Review">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Final Decision Review]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_6</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_5">
+        <bpmn2:dataInput id="DataInput_5" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:inputSet id="_InputSet_5">
+          <bpmn2:dataInputRefs>DataInput_5</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_5" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_5">
+        <bpmn2:targetRef>DataInput_5</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_5">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_9">Final Decision Review</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_10">DataInput_5</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" tns:priority="1" sourceRef="UserTask_4" targetRef="UserTask_5"/>
+    <bpmn2:endEvent id="EndEvent_1" name="End Event 1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[End Event 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_6</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_6" tns:priority="1" sourceRef="UserTask_5" targetRef="EndEvent_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="UserTasksWithSpecialChars">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="45.0" y="45.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_1" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="52.0" x="37.0" y="81.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="150.0" y="38.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_2" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="60.0" x="175.0" y="57.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_2" bpmnElement="UserTask_2" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="320.0" y="38.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_3" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="80.0" x="335.0" y="57.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_3" bpmnElement="UserTask_3" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="490.0" y="38.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_4" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="70.0" x="510.0" y="57.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_4" bpmnElement="UserTask_4" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="660.0" y="38.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_5" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="90.0" x="670.0" y="57.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="830.0" y="45.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_6" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="50.0" x="823.0" y="81.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_UserTask_1">
+        <di:waypoint xsi:type="dc:Point" x="81.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="115.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="150.0" y="63.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_6"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_UserTask_1" targetElement="BPMNShape_UserTask_2">
+        <di:waypoint xsi:type="dc:Point" x="260.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="320.0" y="63.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_7"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_UserTask_2" targetElement="BPMNShape_UserTask_3">
+        <di:waypoint xsi:type="dc:Point" x="430.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="460.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="490.0" y="63.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_8"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="BPMNShape_UserTask_3" targetElement="BPMNShape_UserTask_4">
+        <di:waypoint xsi:type="dc:Point" x="600.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="630.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="660.0" y="63.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_9"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_UserTask_4" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="770.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="800.0" y="63.0"/>
+        <di:waypoint xsi:type="dc:Point" x="830.0" y="63.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_10"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="BPMNLabelStyle_1">
+      <dc:Font name="arial" size="9.0"/>
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessResourceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessResourceGenerator.java
@@ -395,7 +395,7 @@ public class ProcessResourceGenerator {
             SwitchStmt switchExpr = taskModelFactoryMethod.getBody().map(b -> b.findFirst(SwitchStmt.class).orElseThrow(IllegalStateException::new)).orElseThrow(IllegalStateException::new);
 
             for (WorkItemModelMetaData workItem : workItems) {
-                String methodSuffix = sanitizeName(workItem.getName()) + "_" + index.getAndIncrement();
+                String methodSuffix = sanitizeJavaName(workItem.getName()) + "_" + index.getAndIncrement();
                 userTaskTemplate.findAll(MethodDeclaration.class).forEach(md -> {
                     MethodDeclaration cloned = md.clone();
                     template.addMethod(cloned.getName() + "_" + methodSuffix, Keyword.PUBLIC)


### PR DESCRIPTION
closes: https://github.com/apache/incubator-kie-issues/issues/2317

Code generation fails for Task Name containing hyphen as well as other special characters

Valid Java identifier characters include: (should not be replaced in method name)
* ✅ Letters (a-z, A-Z)
* ✅ Digits (0-9)
* ✅ Underscore (_)
* ✅ Dollar sign ($) ← This is valid!
Invalid characters that get replaced:
* ❌ Hyphen (-)
* ❌ Space ( )
* ❌ Dot (.)
* ❌ At sign (@)


Steps for testing
Update the taskname / create a bpmn with taskname containing a hyphen
Try to run the business service with the bpmn file
The code should be generated successfully without failure
The {process}Resource.java file genertaed should not have any compilation issues and methods like below will be present (The hyphen in method name should be replaced)
```
@GET
    @Path("/{id}/hr-interview/{taskId}/schema")
    @Produces(MediaType.APPLICATION_JSON)
    @jakarta.transaction.Transactional()
    @org.eclipse.microprofile.faulttolerance.Retry()
    public Map<String, Object> getSchemaAndPhases_hr_interview_1(@PathParam("id") final String id, @PathParam("taskId") final String taskId, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups) {
        return processService.getWorkItemSchemaAndPhases(process, id, taskId, "hr-interview", SecurityPolicy.of(identityProviderFactory.getOrImpersonateIdentity(user, groups)));
    }
```
The url will still remain
`/{id}/hr-interview/{taskId}/schema`