### PR TITLE
exclusion for com.aayushatharva.brotli4j artifacts in the  netty-codec-http dependency to fix native build issue

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -681,6 +681,12 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
         <version>${version.io.netty}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Add exclusion for com.aayushatharva.brotli4j artifacts in the netty-codec-http dependency to fix native build issue