### PR TITLE
[kie_pmml_dependencies_packaging] Changing packaging/type of kie-pmml-dependencies to pom

### DIFF
--- a/drools/kogito-pmml-dependencies/pom.xml
+++ b/drools/kogito-pmml-dependencies/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-pmml-dependencies</artifactId>
+      <type>pom</type>
       <exclusions>
         <!-- Drools models -->
         <!-- Tree -->


### PR DESCRIPTION
Relates to:
https://github.com/apache/incubator-kie-drools/pull/6731


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


