### PR TITLE
[CVE][Critical] CVE-2026-40973, CVE-2026-40975, CVE-2026-40976, CVE-2026-40977 spring-boot-4.0.5.jar

### DIFF
--- a/springboot/bom/pom.xml
+++ b/springboot/bom/pom.xml
@@ -42,7 +42,7 @@
     <version.mongodb-driver-sync>5.6.4</version.mongodb-driver-sync>
     <version.org.springdoc>2.8.13</version.org.springdoc>
     <version.org.springframework>7.0.7</version.org.springframework>
-    <version.org.springframework.boot>4.0.5</version.org.springframework.boot>
+    <version.org.springframework.boot>4.0.6</version.org.springframework.boot>
     <!-- Spring Boot Cloud aligned with Spring Boot Framework version. See: https://spring.io/projects/spring-cloud -->
     <!-- 2025.1.x (Oakwood) is the first Spring Cloud train compatible with Spring Boot 4.0.x;
          2025.1.1 specifically targets Spring Boot 4.0.1+. -->


### PR DESCRIPTION
## Summary
Bumps the managed **Spring Boot version from 4.0.5 → 4.0.6** in optaplanner.
Because no Spring Security version is pinned, this also pulls **Spring Security
7.0.4 → 7.0.5** transitively via `spring-boot-dependencies`, remediating the
Spring Boot CVEs flagged in this repo.

## CVEs remediated
| Package | CVEs |
|---------|------|
| spring-boot | CVE-2026-40973, CVE-2026-40975, CVE-2026-40976, CVE-2026-40977 |
| spring-boot-autoconfigure | CVE-2026-40974, CVE-2026-40971 |
| spring-boot-security | CVE-2026-40976 |
| spring-security-oauth2-jose | CVE-2026-22748 |
| spring-security-web | CVE-2026-22747 |
| spring-security-config | CVE-2026-22754, CVE-2026-22753 |
| spring-security-core | CVE-2026-22751, CVE-2026-22746 |

## Changes
- `springboot/bom/pom.xml` — `version.org.springframework.boot` 4.0.5 → 4.0.6

## Connected PRs
- optaplanner  — https://github.com/apache/incubator-kie-optaplanner/pull/3232
- kie-tools - https://github.com/apache/incubator-kie-tools/pull/3618
- kogito-examples - https://github.com/apache/incubator-kie-kogito-examples/pull/2215
