### PR TITLE
[kie-issues#2337] Fix intermittent resource generation in kogito-gradle-plugin

### DIFF
--- a/kogito-gradle-plugin/src/main/java/org/kie/kogito/gradle/plugin/AbstractKieTask.java
+++ b/kogito-gradle-plugin/src/main/java/org/kie/kogito/gradle/plugin/AbstractKieTask.java
@@ -55,7 +55,7 @@ public abstract class AbstractKieTask extends DefaultTask {
     @Internal
     protected String gradleCompilerJavaVersion;
 
-    @Internal
+    @OutputDirectory
     protected Property<File> projectBuildOutputDirectory;
 
     @Internal


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2337

## Summary

Fix intermittent resource generation in `kogito-gradle-plugin` by declaring the Gradle build output directory as a task output.

In some Spring Boot Gradle projects, generated files such as:
- `kie-spring-boot-config.properties`
- `dmnModelPaths.txt`

were intermittently missing after clean builds, causing flaky test behavior.

## Root cause

`GenerateModelTask` delegates generation to `BuilderManager`, which writes artifacts under the project build output directory.

However, that directory was previously marked as `@Internal`, so Gradle was not aware that `generateModel` produced outputs there. This could lead to incorrect incremental/up-to-date behavior and intermittent missing generated files.

## Fix

Change `projectBuildOutputDirectory` in `AbstractKieTask` from:

```java
@Internal
protected Property<File> projectBuildOutputDirectory;
```
to:

```java
@OutputDirectory
protected Property<File> projectBuildOutputDirectory;
```

This makes Gradle track the actual output location used by the task.

