### PR TITLE
Fix CVE-2024-6763, CVE-2025-11143, CVE-2026-2332: Replace wiremock with wiremock-jetty12

### DIFF
--- a/addons/common/kubernetes/pom.xml
+++ b/addons/common/kubernetes/pom.xml
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -1057,6 +1057,12 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
+      <dependency>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock-jetty12</artifactId>
+        <version>${version.org.wiremock}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -1057,12 +1057,6 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
-      <dependency>
-        <groupId>org.wiremock</groupId>
-        <artifactId>wiremock-jetty12</artifactId>
-        <version>${version.org.wiremock}</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/quarkus/addons/kubernetes/runtime/pom.xml
+++ b/quarkus/addons/kubernetes/runtime/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -140,7 +140,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
@@ -112,7 +112,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This PR replaces `wiremock` and `wiremock-standalone` artifacts with `wiremock-jetty12` in test dependencies to resolve four Jetty CVEs.

**Background**
This change is part of a coordinated fix across multiple repositories to upgrade Jetty from 11.0.24 to 12.0.33. The parent repository (Drools kie-parent) has been updated to manage Jetty 12.0.33 and WireMock 3.13.2.

**Changes Made**
Replaced `wiremock`/`wiremock-standalone` with `wiremock-jetty12` in 6 pom.xml files:

**Impact**
- All test dependencies now use `wiremock-jetty12` which pulls Jetty 12.0.33
- Inherits Jetty version management from Drools kie-parent
- No functional changes to tests