### PR TITLE
[incubator kie issues#2349] Annotate "properties" in code-base 

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/auth/IdentityProviderFactory.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/auth/IdentityProviderFactory.java
@@ -31,7 +31,7 @@ public interface IdentityProviderFactory {
     /**
      * Enables (true) using the application security context when resolving current User Identity. Defaults to false.
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "false", allowedValues = "true,false")
     String KOGITO_SECURITY_AUTH_ENABLED = "kogito.security.auth.enabled";
 
     /**

--- a/api/kogito-api/src/main/java/org/kie/kogito/auth/IdentityProviderFactory.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/auth/IdentityProviderFactory.java
@@ -21,6 +21,8 @@ package org.kie.kogito.auth;
 
 import java.util.Collection;
 
+import org.kie.api.annotations.KieProperty;
+
 /**
  * Factory that resolves the {@link IdentityProvider}
  */
@@ -29,11 +31,13 @@ public interface IdentityProviderFactory {
     /**
      * Enables (true) using the application security context when resolving current User Identity. Defaults to false.
      */
+    @KieProperty
     String KOGITO_SECURITY_AUTH_ENABLED = "kogito.security.auth.enabled";
 
     /**
      * Comma-separated list of roles that allow identity impersonation when resolving the actual User Identity.
      */
+    @KieProperty
     String KOGITO_SECURITY_AUTH_IMPERSONATION_ALLOWED_FOR_ROLES = "kogito.security.auth.impersonation.allowed-for-roles";
 
     IdentityProvider getOrImpersonateIdentity(String user, Collection<String> roles);

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.kie.api.annotations.KieProperty;
+import org.kie.api.annotations.KieInternal;
 import org.kie.kogito.event.cloudevents.CloudEventExtensionConstants;
 import org.kie.kogito.event.cloudevents.SpecVersionDeserializer;
 import org.kie.kogito.event.cloudevents.SpecVersionSerializer;
@@ -72,7 +72,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
      * Since this is a required field, the constructor will fill them with this default value.
      * Ideally, callers would use #TYPE_FORMAT to fill this field using the process name and the signal node name, e.g: process.travelagency.visaapproved
      */
-    @KieProperty
+    @KieInternal
     public static final String TYPE_PREFIX = "process";
     public static final String TYPE_FORMAT = TYPE_PREFIX + ".%s.%s";
     /**
@@ -80,7 +80,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
      * Since this is a required field, the constructor will fill them with default value, e.g.: /process/travelagency
      * See more about the source format: https://github.com/cloudevents/spec/blob/v1.0/spec.md#source-1
      */
-    @KieProperty
+    @KieInternal
     public static final String SOURCE_FORMAT = "/process/%s";
     public static final String SPEC_VERSION = "1.0";
     public static final String DATA_CONTENT_TYPE = "application/json";

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.kie.api.annotations.KieProperty;
 import org.kie.kogito.event.cloudevents.CloudEventExtensionConstants;
 import org.kie.kogito.event.cloudevents.SpecVersionDeserializer;
 import org.kie.kogito.event.cloudevents.SpecVersionSerializer;
@@ -71,6 +72,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
      * Since this is a required field, the constructor will fill them with this default value.
      * Ideally, callers would use #TYPE_FORMAT to fill this field using the process name and the signal node name, e.g: process.travelagency.visaapproved
      */
+    @KieProperty
     public static final String TYPE_PREFIX = "process";
     public static final String TYPE_FORMAT = TYPE_PREFIX + ".%s.%s";
     /**
@@ -78,6 +80,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
      * Since this is a required field, the constructor will fill them with default value, e.g.: /process/travelagency
      * See more about the source format: https://github.com/cloudevents/spec/blob/v1.0/spec.md#source-1
      */
+    @KieProperty
     public static final String SOURCE_FORMAT = "/process/%s";
     public static final String SPEC_VERSION = "1.0";
     public static final String DATA_CONTENT_TYPE = "application/json";

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/context/ProcessInstanceContext.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/context/ProcessInstanceContext.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.kie.api.annotations.KieProperty;
+import org.kie.api.annotations.KieInternal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -48,14 +48,14 @@ public final class ProcessInstanceContext {
      * MDC key used to store the process instance ID.
      * This key should be referenced in logging configurations.
      */
-    @KieProperty
+    @KieInternal
     public static final String MDC_PROCESS_INSTANCE_KEY = "processInstanceId";
 
     /**
      * Default value used when no process instance ID is available.
      * Empty string for cleaner log formatting and easier searching.
      */
-    @KieProperty
+    @KieInternal
     public static final String GENERAL_CONTEXT = "";
 
     // Private constructor to prevent instantiation

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/context/ProcessInstanceContext.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/context/ProcessInstanceContext.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.kie.api.annotations.KieProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -47,12 +48,14 @@ public final class ProcessInstanceContext {
      * MDC key used to store the process instance ID.
      * This key should be referenced in logging configurations.
      */
+    @KieProperty
     public static final String MDC_PROCESS_INSTANCE_KEY = "processInstanceId";
 
     /**
      * Default value used when no process instance ID is available.
      * Empty string for cleaner log formatting and easier searching.
      */
+    @KieProperty
     public static final String GENERAL_CONTEXT = "";
 
     // Private constructor to prevent instantiation

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/ExtensibleXmlParser.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/ExtensibleXmlParser.java
@@ -43,6 +43,7 @@ import javax.xml.parsers.SAXParserFactory;
 import org.jbpm.compiler.xml.Handler;
 import org.jbpm.compiler.xml.Parser;
 import org.jbpm.compiler.xml.SemanticModule;
+import org.kie.api.annotations.KieProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -74,6 +75,7 @@ public class ExtensibleXmlParser extends DefaultHandler implements Parser {
     public static final String ENTITY_RESOLVER_PROPERTY_NAME = "org.drools.core.io.EntityResolver";
 
     /** Namespace URI for the general tags. */
+    @KieProperty
     public static final String RULES_NAMESPACE_URI = "http://drools.org/rules";
 
     private static final String JAXP_SCHEMA_LANGUAGE = "http://java.sun.com/xml/jaxp/properties/schemaLanguage";

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/ExtensibleXmlParser.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/ExtensibleXmlParser.java
@@ -43,7 +43,7 @@ import javax.xml.parsers.SAXParserFactory;
 import org.jbpm.compiler.xml.Handler;
 import org.jbpm.compiler.xml.Parser;
 import org.jbpm.compiler.xml.SemanticModule;
-import org.kie.api.annotations.KieProperty;
+import org.kie.api.annotations.KieInternal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -75,7 +75,7 @@ public class ExtensibleXmlParser extends DefaultHandler implements Parser {
     public static final String ENTITY_RESOLVER_PROPERTY_NAME = "org.drools.core.io.EntityResolver";
 
     /** Namespace URI for the general tags. */
-    @KieProperty
+    @KieInternal
     public static final String RULES_NAMESPACE_URI = "http://drools.org/rules";
 
     private static final String JAXP_SCHEMA_LANGUAGE = "http://java.sun.com/xml/jaxp/properties/schemaLanguage";

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/Generator.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/Generator.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
+import org.kie.api.annotations.KieProperty;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
 /**
@@ -35,6 +36,7 @@ public interface Generator {
     /**
      * kogito.codegen.(engine_name) -> (boolean) enable/disable engine code generation (default true)
      */
+    @KieProperty
     String CONFIG_PREFIX = "kogito.codegen.";
 
     /**

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/Generator.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/Generator.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
-import org.kie.api.annotations.KieProperty;
+import org.kie.api.annotations.KieInternal;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
 /**
@@ -36,7 +36,7 @@ public interface Generator {
     /**
      * kogito.codegen.(engine_name) -> (boolean) enable/disable engine code generation (default true)
      */
-    @KieProperty
+    @KieInternal
     String CONFIG_PREFIX = "kogito.codegen.";
 
     /**

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
@@ -19,14 +19,13 @@
 package org.kie.kogito.codegen.api.context;
 
 import org.kie.api.annotations.KieInternal;
-import org.kie.api.annotations.KieProperty;
 
 public final class ContextAttributesConstants {
 
     /**
      * computes the triggers being generated
      */
-    @KieProperty
+    @KieInternal
     public static final String PROCESS_TRIGGERS = "kogito.codegen.process.triggers";
 
     /**

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
@@ -18,16 +18,20 @@
  */
 package org.kie.kogito.codegen.api.context;
 
+import org.kie.api.annotations.KieProperty;
+
 public final class ContextAttributesConstants {
 
     /**
      * computes the triggers being generated
      */
+    @KieProperty
     public static final String PROCESS_TRIGGERS = "kogito.codegen.process.triggers";
 
     /**
      * OpenAPI Generator Descriptors with information of every REST client generated indexed by the spec resource file.
      */
+    @KieProperty
     public static final String OPENAPI_DESCRIPTORS = "openApiDescriptor";
 
     public static final String PROCESS_AUTO_SVG_MAPPING = "processAutoSVGMapping";

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/ContextAttributesConstants.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.codegen.api.context;
 
+import org.kie.api.annotations.KieInternal;
 import org.kie.api.annotations.KieProperty;
 
 public final class ContextAttributesConstants {
@@ -31,7 +32,7 @@ public final class ContextAttributesConstants {
     /**
      * OpenAPI Generator Descriptors with information of every REST client generated indexed by the spec resource file.
      */
-    @KieProperty
+    @KieInternal
     public static final String OPENAPI_DESCRIPTORS = "openApiDescriptor";
 
     public static final String PROCESS_AUTO_SVG_MAPPING = "processAutoSVGMapping";

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/KogitoCodeGenConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/KogitoCodeGenConstants.java
@@ -18,6 +18,8 @@
  */
 package org.kie.kogito.codegen.api.utils;
 
+import org.kie.api.annotations.KieProperty;
+
 public class KogitoCodeGenConstants {
 
     private KogitoCodeGenConstants() {
@@ -31,5 +33,6 @@ public class KogitoCodeGenConstants {
     /**
      * Property that controls whether Kogito Codegen should ignore hidden files. Defaults to true.
      */
+    @KieProperty
     public static final String IGNORE_HIDDEN_FILES_PROP = "kogito.codegen.ignoreHiddenFiles";
 }

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/KogitoCodeGenConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/KogitoCodeGenConstants.java
@@ -38,6 +38,6 @@ public class KogitoCodeGenConstants {
     /**
      * Property that controls whether Kogito Codegen should ignore hidden files. Defaults to true.
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "true", allowedValues = "true,false")
     public static final String IGNORE_HIDDEN_FILES_PROP = "kogito.codegen.ignoreHiddenFiles";
 }

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/KogitoCodeGenConstants.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/KogitoCodeGenConstants.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.codegen.api.utils;
 
+import org.kie.api.annotations.KieInternal;
 import org.kie.api.annotations.KieProperty;
 
 public class KogitoCodeGenConstants {
@@ -26,9 +27,13 @@ public class KogitoCodeGenConstants {
 
     }
 
+    @KieInternal
     public static final String VALIDATION_CLASS = "jakarta.validation.constraints.NotNull";
+    @KieInternal
     public static final String OPENAPI_SPEC_CLASS = "org.eclipse.microprofile.openapi.annotations.media.Schema";
+    @KieInternal
     public static final String QUARKUS_TRANSACTION_MANAGER_CLASS = "io.quarkus.narayana.jta.QuarkusTransaction";
+    @KieInternal
     public static final String SPRING_TRANSACTION_MANAGER_CLASS = "org.springframework.transaction.PlatformTransactionManager";
     /**
      * Property that controls whether Kogito Codegen should ignore hidden files. Defaults to true.

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/GeneratorConfig.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/GeneratorConfig.java
@@ -18,6 +18,8 @@
  */
 package org.kie.kogito.codegen.core;
 
+import org.kie.api.annotations.KieProperty;
+
 /**
  * GeneratorConfig
  */
@@ -26,6 +28,7 @@ public class GeneratorConfig {
     /**
      * the type of generated rest (currently used only by processes); possible values: reactive; (default is empty)
      */
+    @KieProperty
     public static final String KOGITO_REST_RESOURCE_TYPE_PROP = "kogito.rest.resource.type";
 
     private GeneratorConfig() {

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/GeneratorConfig.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/GeneratorConfig.java
@@ -28,7 +28,7 @@ public class GeneratorConfig {
     /**
      * the type of generated rest (currently used only by processes); possible values: reactive; (default is empty)
      */
-    @KieProperty
+    @KieProperty(type = "string", defaultValue = "", allowedValues = "reactive")
     public static final String KOGITO_REST_RESOURCE_TYPE_PROP = "kogito.rest.resource.type";
 
     private GeneratorConfig() {

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/utils/CodegenUtil.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/utils/CodegenUtil.java
@@ -20,6 +20,7 @@ package org.kie.kogito.codegen.core.utils;
 
 import java.util.function.Function;
 
+import org.kie.api.annotations.KieProperty;
 import org.kie.kogito.codegen.api.Generator;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
@@ -35,11 +36,13 @@ public final class CodegenUtil {
     /**
      * Flag used to configure transaction enabling. Default to <code>true</code>
      */
+    @KieProperty
     public static final String TRANSACTION_ENABLED = "transactionEnabled";
 
     /**
      * Flag used to configure fault tolerance enabling. Default to <code>true</code>
      */
+    @KieProperty
     public static final String FAULT_TOLERANCE_ENABLED = "faultToleranceEnabled";
 
     private CodegenUtil() {

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/utils/CodegenUtil.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/utils/CodegenUtil.java
@@ -54,7 +54,7 @@ public final class CodegenUtil {
      * 
      * @param generator
      * @param propertyName
-     * @return returns the property for certain generator
+     * @return the property for certain generator
      */
     public static String generatorProperty(Generator generator, String propertyName) {
         return String.format("kogito.%s.%s", generator.name(), propertyName);

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/utils/CodegenUtil.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/utils/CodegenUtil.java
@@ -36,13 +36,13 @@ public final class CodegenUtil {
     /**
      * Flag used to configure transaction enabling. Default to <code>true</code>
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "true", allowedValues = "true,false")
     public static final String TRANSACTION_ENABLED = "transactionEnabled";
 
     /**
      * Flag used to configure fault tolerance enabling. Default to <code>true</code>
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "true", allowedValues = "true,false")
     public static final String FAULT_TOLERANCE_ENABLED = "faultToleranceEnabled";
 
     private CodegenUtil() {

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -61,40 +61,40 @@ public class DecisionCodegen extends AbstractGenerator {
     /**
      * (boolean) generate java classes to support strongly typed input (default false)
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "false", allowedValues = "true,false")
     public static final String STRONGLY_TYPED_CONFIGURATION_KEY = "kogito.decisions.stronglytyped";
     /**
      * model validation strategy; possible values: ENABLED, DISABLED, IGNORE; (default ENABLED)
      */
-    @KieProperty
+    @KieProperty(type = "string", defaultValue = "ENABLED", allowedValues = "ENABLED,DISABLED,IGNORE")
     public static final String VALIDATION_CONFIGURATION_KEY = "kogito.decisions.validation";
 
     /**
      * (string) kafka bootstrap server address
      */
-    @KieProperty
+    @KieProperty(type = "string")
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_BOOTSTRAPADDRESS = "kogito.addon.tracing.decision.kafka.bootstrapAddress";
     /**
      * (string) name of the decision topic; default to kogito-tracing-decision
      */
-    @KieProperty
+    @KieProperty(type = "string", defaultValue = "kogito-tracing-decision")
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_TOPIC_NAME = "kogito.addon.tracing.decision.kafka.topic.name";
     /**
      * (integer) number of decision topic partitions; default to 1
      */
-    @KieProperty
+    @KieProperty(type = "integer", defaultValue = "1")
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_TOPIC_PARTITIONS = "kogito.addon.tracing.decision.kafka.topic.partitions";
 
     /**
      * (integer) number of decision topic replication factor; default to 1
      */
-    @KieProperty
+    @KieProperty(type = "integer", defaultValue = "1")
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_TOPIC_REPLICATION_FACTOR = "kogito.addon.tracing.decision.kafka.topic.replicationFactor";
 
     /**
      * (boolean) enable/disable asynchronous collection of decision events; default to true
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "true", allowedValues = "true,false")
     public static final String KOGITO_ADDON_TRACING_DECISION_ASYNC_ENABLED = "kogito.addon.tracing.decision.asyncEnabled";
 
     public static DecisionCodegen ofCollectedResources(KogitoBuildContext context, Collection<CollectedResource> resources) {

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -72,7 +72,7 @@ public class DecisionCodegen extends AbstractGenerator {
     /**
      * (string) kafka bootstrap server address
      */
-    @KieProperty(type = "string")
+    @KieProperty(type = "string", defaultValue = "")
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_BOOTSTRAPADDRESS = "kogito.addon.tracing.decision.kafka.bootstrapAddress";
     /**
      * (string) name of the decision topic; default to kogito-tracing-decision

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
+import org.kie.api.annotations.KieProperty;
 import org.kie.api.io.ResourceType;
 import org.kie.dmn.core.compiler.DMNProfile;
 import org.kie.dmn.core.compiler.RuntimeTypeCheckOption;
@@ -69,24 +70,29 @@ public class DecisionCodegen extends AbstractGenerator {
     /**
      * (string) kafka bootstrap server address
      */
+    @KieProperty
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_BOOTSTRAPADDRESS = "kogito.addon.tracing.decision.kafka.bootstrapAddress";
     /**
      * (string) name of the decision topic; default to kogito-tracing-decision
      */
+    @KieProperty
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_TOPIC_NAME = "kogito.addon.tracing.decision.kafka.topic.name";
     /**
      * (integer) number of decision topic partitions; default to 1
      */
+    @KieProperty
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_TOPIC_PARTITIONS = "kogito.addon.tracing.decision.kafka.topic.partitions";
 
     /**
      * (integer) number of decision topic replication factor; default to 1
      */
+    @KieProperty
     public static final String KOGITO_ADDON_TRACING_DECISION_KAFKA_TOPIC_REPLICATION_FACTOR = "kogito.addon.tracing.decision.kafka.topic.replicationFactor";
 
     /**
      * (boolean) enable/disable asynchronous collection of decision events; default to true
      */
+    @KieProperty
     public static final String KOGITO_ADDON_TRACING_DECISION_ASYNC_ENABLED = "kogito.addon.tracing.decision.asyncEnabled";
 
     public static DecisionCodegen ofCollectedResources(KogitoBuildContext context, Collection<CollectedResource> resources) {

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -61,11 +61,13 @@ public class DecisionCodegen extends AbstractGenerator {
     /**
      * (boolean) generate java classes to support strongly typed input (default false)
      */
-    public static String STRONGLY_TYPED_CONFIGURATION_KEY = "kogito.decisions.stronglytyped";
+    @KieProperty
+    public static final String STRONGLY_TYPED_CONFIGURATION_KEY = "kogito.decisions.stronglytyped";
     /**
      * model validation strategy; possible values: ENABLED, DISABLED, IGNORE; (default ENABLED)
      */
-    public static String VALIDATION_CONFIGURATION_KEY = "kogito.decisions.validation";
+    @KieProperty
+    public static final String VALIDATION_CONFIGURATION_KEY = "kogito.decisions.validation";
 
     /**
      * (string) kafka bootstrap server address

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.infinispan.protostream.FileDescriptorSource;
+import org.kie.api.annotations.KieInternal;
 import org.kie.api.annotations.KieProperty;
 import org.kie.kogito.codegen.api.ApplicationSection;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
@@ -71,13 +72,19 @@ public class PersistenceGenerator extends AbstractGenerator {
     /**
      * Type of persistence
      */
-    @KieProperty
+    @KieInternal
     public static final String FILESYSTEM_PERSISTENCE_TYPE = "filesystem";
+    @KieInternal
     public static final String INFINISPAN_PERSISTENCE_TYPE = "infinispan";
+    @KieInternal
     public static final String MONGODB_PERSISTENCE_TYPE = "mongodb";
+    @KieInternal
     public static final String POSTGRESQL_PERSISTENCE_TYPE = "postgresql";
+    @KieInternal
     public static final String KAFKA_PERSISTENCE_TYPE = "kafka";
+    @KieInternal
     public static final String JDBC_PERSISTENCE_TYPE = "jdbc";
+    @KieInternal
     public static final String DEFAULT_PERSISTENCE_TYPE = INFINISPAN_PERSISTENCE_TYPE;
 
     /**
@@ -89,12 +96,14 @@ public class PersistenceGenerator extends AbstractGenerator {
      */
     @KieProperty
     public static final String KOGITO_PERSISTENCE_DATA_INDEX_PROTO_GENERATION = "kogito.persistence.data-index.proto.generation";
+    @KieInternal
     public static final String KOGITO_PERSISTENCE_DATA_INDEX_PROTO_GENERATION_DEFAULT = "true";
     /**
      * (boolean) enable/disable proto marshaller generation; default to true
      */
     @KieProperty
     public static final String KOGITO_PERSISTENCE_PROTO_MARSHALLER = "kogito.persistence.proto.marshaller";
+    @KieInternal
     public static final String KOGITO_PERSISTENCE_PROTO_MARSHALLER_DEFAULT = "true";
     /**
      * (string) kind of persistence used; possible values: filesystem, infinispan, mongodb, postgresql, kafka, jdbc; default to infinispan

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.infinispan.protostream.FileDescriptorSource;
+import org.kie.api.annotations.KieProperty;
 import org.kie.kogito.codegen.api.ApplicationSection;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
@@ -70,6 +71,7 @@ public class PersistenceGenerator extends AbstractGenerator {
     /**
      * Type of persistence
      */
+    @KieProperty
     public static final String FILESYSTEM_PERSISTENCE_TYPE = "filesystem";
     public static final String INFINISPAN_PERSISTENCE_TYPE = "infinispan";
     public static final String MONGODB_PERSISTENCE_TYPE = "mongodb";
@@ -85,16 +87,19 @@ public class PersistenceGenerator extends AbstractGenerator {
     /**
      * (boolean) enable/disable proto generation for DATA-INDEX; default to true
      */
+    @KieProperty
     public static final String KOGITO_PERSISTENCE_DATA_INDEX_PROTO_GENERATION = "kogito.persistence.data-index.proto.generation";
     public static final String KOGITO_PERSISTENCE_DATA_INDEX_PROTO_GENERATION_DEFAULT = "true";
     /**
      * (boolean) enable/disable proto marshaller generation; default to true
      */
+    @KieProperty
     public static final String KOGITO_PERSISTENCE_PROTO_MARSHALLER = "kogito.persistence.proto.marshaller";
     public static final String KOGITO_PERSISTENCE_PROTO_MARSHALLER_DEFAULT = "true";
     /**
      * (string) kind of persistence used; possible values: filesystem, infinispan, mongodb, postgresql, kafka, jdbc; default to infinispan
      */
+    @KieProperty
     public static final String KOGITO_PERSISTENCE_TYPE = "kogito.persistence.type";
 
     /**
@@ -106,6 +111,7 @@ public class PersistenceGenerator extends AbstractGenerator {
     /**
      * Generic PersistenceGenerator constants
      */
+    @KieProperty
     public static final String GENERATOR_NAME = "persistence";
     protected static final String CLASS_TEMPLATES_PERSISTENCE = "/class-templates/persistence/";
     private final ProtoGenerator protoGenerator;

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
@@ -94,21 +94,21 @@ public class PersistenceGenerator extends AbstractGenerator {
     /**
      * (boolean) enable/disable proto generation for DATA-INDEX; default to true
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "true", allowedValues = "true,false")
     public static final String KOGITO_PERSISTENCE_DATA_INDEX_PROTO_GENERATION = "kogito.persistence.data-index.proto.generation";
     @KieInternal
     public static final String KOGITO_PERSISTENCE_DATA_INDEX_PROTO_GENERATION_DEFAULT = "true";
     /**
      * (boolean) enable/disable proto marshaller generation; default to true
      */
-    @KieProperty
+    @KieProperty(type = "boolean", defaultValue = "true", allowedValues = "true,false")
     public static final String KOGITO_PERSISTENCE_PROTO_MARSHALLER = "kogito.persistence.proto.marshaller";
     @KieInternal
     public static final String KOGITO_PERSISTENCE_PROTO_MARSHALLER_DEFAULT = "true";
     /**
      * (string) kind of persistence used; possible values: filesystem, infinispan, mongodb, postgresql, kafka, jdbc; default to infinispan
      */
-    @KieProperty
+    @KieProperty(type = "string", defaultValue = "infinispan", allowedValues = "filesystem,infinispan,mongodb,postgresql,kafka,jdbc")
     public static final String KOGITO_PERSISTENCE_TYPE = "kogito.persistence.type";
 
     /**
@@ -120,7 +120,7 @@ public class PersistenceGenerator extends AbstractGenerator {
     /**
      * Generic PersistenceGenerator constants
      */
-    @KieProperty
+    @KieInternal
     public static final String GENERATOR_NAME = "persistence";
     protected static final String CLASS_TEMPLATES_PERSISTENCE = "/class-templates/persistence/";
     private final ProtoGenerator protoGenerator;

--- a/quarkus/addons/knative/eventing/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/KnativeEventingConfigSource.java
+++ b/quarkus/addons/knative/eventing/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/KnativeEventingConfigSource.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.kie.api.annotations.KieProperty;
 
 /**
  * Provides the default configuration for a Kogito project that uses Knative Eventing as underling event platform
@@ -31,6 +32,7 @@ public class KnativeEventingConfigSource implements ConfigSource {
     /**
      * Environment variable injected by Knative
      */
+    @KieProperty
     public static final String K_SINK = "K_SINK";
 
     static final Integer ORDINAL = Integer.MIN_VALUE;

--- a/quarkus/addons/knative/eventing/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/KnativeEventingConfigSource.java
+++ b/quarkus/addons/knative/eventing/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/KnativeEventingConfigSource.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.kie.api.annotations.KieProperty;
+import org.kie.api.annotations.KieInternal;
 
 /**
  * Provides the default configuration for a Kogito project that uses Knative Eventing as underling event platform
@@ -32,7 +32,7 @@ public class KnativeEventingConfigSource implements ConfigSource {
     /**
      * Environment variable injected by Knative
      */
-    @KieProperty
+    @KieInternal
     public static final String K_SINK = "K_SINK";
 
     static final Integer ORDINAL = Integer.MIN_VALUE;

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
@@ -20,6 +20,7 @@ package org.kie.kogito.quarkus.workflow.deployment.devservices;
 
 import java.time.Duration;
 
+import org.kie.api.annotations.KieProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -39,6 +40,7 @@ public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemo
     /**
      * This allows other applications to discover the running service and use it instead of starting a new instance.
      */
+    @KieProperty
     public static final String DEV_SERVICE_LABEL = "kogito-dev-service-data-index";
     public static final String LATEST = "latest";
     private static final Logger LOGGER = LoggerFactory.getLogger(DataIndexInMemoryContainer.class);

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
@@ -21,7 +21,6 @@ package org.kie.kogito.quarkus.workflow.deployment.devservices;
 import java.time.Duration;
 
 import org.kie.api.annotations.KieInternal;
-import org.kie.api.annotations.KieProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -41,7 +40,7 @@ public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemo
     /**
      * This allows other applications to discover the running service and use it instead of starting a new instance.
      */
-    @KieProperty
+    @KieInternal
     public static final String DEV_SERVICE_LABEL = "kogito-dev-service-data-index";
     @KieInternal
     public static final String LATEST = "latest";

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/src/main/java/org/kie/kogito/quarkus/workflow/deployment/devservices/DataIndexInMemoryContainer.java
@@ -20,6 +20,7 @@ package org.kie.kogito.quarkus.workflow.deployment.devservices;
 
 import java.time.Duration;
 
+import org.kie.api.annotations.KieInternal;
 import org.kie.api.annotations.KieProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemo
      */
     @KieProperty
     public static final String DEV_SERVICE_LABEL = "kogito-dev-service-data-index";
+    @KieInternal
     public static final String LATEST = "latest";
     private static final Logger LOGGER = LoggerFactory.getLogger(DataIndexInMemoryContainer.class);
 

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
@@ -20,6 +20,7 @@ package org.kie.kogito.quarkus.workflow;
 
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.kie.api.annotations.KieProperty;
 import org.kie.kogito.config.ConfigBean;
 import org.kie.kogito.correlation.CorrelationService;
 import org.kie.kogito.event.correlation.DefaultCorrelationService;
@@ -47,6 +48,7 @@ public class KogitoBeanProducer {
     /**
      * (string) strategy to resolve a Process version to use; possible values: project, workflow; if "project", requires project GAV; default is workflow
      */
+    @KieProperty
     public static final String KOGITO_WORKFLOW_VERSION_STRATEGY = "kogito.workflow.version-strategy";
 
     @DefaultBean

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
@@ -48,7 +48,7 @@ public class KogitoBeanProducer {
     /**
      * (string) strategy to resolve a Process version to use; possible values: project, workflow; if "project", requires project GAV; default is workflow
      */
-    @KieProperty
+    @KieProperty(type = "string", defaultValue = "workflow", allowedValues = "project,workflow")
     public static final String KOGITO_WORKFLOW_VERSION_STRATEGY = "kogito.workflow.version-strategy";
 
     @DefaultBean


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2349

Depends on
https://github.com/apache/incubator-kie-drools/pull/6766

This PR:
1. annotate user-configurable properties with `@KieProperty`
2. annotate internal-usage constants with `@KieInternal`

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


