### PR TITLE
[Fix_#4322] Upgrade redpanda version for testcontainers in Quarkus integration tests

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -52,7 +52,7 @@
     <!-- container images for testing -->
     <container.image.infinispan>infinispan/server:${version.org.infinispan}</container.image.infinispan>
     <container.image.keycloak>quay.io/keycloak/keycloak:${version.org.keycloak}</container.image.keycloak>
-    <container.image.kafka>redpandadata/redpanda:v24.3.1</container.image.kafka>
+    <container.image.kafka>redpandadata/redpanda:v24.3.6</container.image.kafka>
     <container.image.wurstmeister.kafka>wurstmeister/kafka:${version.wurstmeister.kafka}</container.image.wurstmeister.kafka>
     <container.image.mongodb>library/mongo:${version.org.mongo-image}</container.image.mongodb>
     <container.image.redis>redislabs/redisearch:${version.org.redis}</container.image.redis>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-kogito-runtimes/issues/4322