### PR TITLE
[incubator-kie-issues#2355] Workflow Engine: Data audit storing null …

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/uow/events/UnitOfWorkProcessEventListener.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/uow/events/UnitOfWorkProcessEventListener.java
@@ -68,12 +68,12 @@ public class UnitOfWorkProcessEventListener extends DefaultKogitoProcessEventLis
 
     @Override
     public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
-        intercept(event);
+
     }
 
     @Override
     public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
-
+        intercept(event);
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/tests/PublishEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/tests/PublishEventIT.java
@@ -529,6 +529,56 @@ public class PublishEventIT extends AbstractCodegenIT {
                 .isNotNull().containsEntry("s", "Goodbye Hello john!!");
     }
 
+    @Test
+    public void testUserTaskNodeEnterEventContainsWorkItemId() throws Exception {
+        Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
+        assertThat(app).isNotNull();
+
+        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+
+        Model model = p.createModel();
+        model.fromMap(Collections.emptyMap());
+
+        TestEventPublisher publisher = new TestEventPublisher();
+        app.unitOfWorkManager().eventManager().setService("http://myhost");
+        app.unitOfWorkManager().eventManager().addPublisher(publisher);
+
+        UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
+        uow.start();
+
+        ProcessInstance<?> processInstance = p.createInstance(model);
+        processInstance.start();
+
+        uow.end();
+
+        assertThat(processInstance.status())
+                .isEqualTo(ProcessInstance.STATE_ACTIVE);
+
+        List<WorkItem> workItems = processInstance.workItems(securityPolicy);
+
+        assertThat(workItems).hasSize(1);
+        assertThat(workItems.get(0).getName()).isEqualTo("FirstTask");
+        assertThat(workItems.get(0).getId()).isNotNull();
+
+        List<DataEvent<?>> events = publisher.extract();
+
+        List<ProcessInstanceNodeEventBody> nodeEnterEvents = findNodeInstanceEvents(
+                events,
+                ProcessInstanceNodeEventBody.EVENT_TYPE_ENTER);
+
+        ProcessInstanceNodeEventBody humanTaskNodeEvent = nodeEnterEvents.stream()
+                .filter(event -> "HumanTaskNode".equals(event.getNodeType()))
+                .filter(event -> "First Task".equals(event.getNodeName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "HumanTaskNode ENTER event was not published"));
+
+        assertThat(humanTaskNodeEvent.getWorkItemId())
+                .as("HumanTaskNode ENTER event must contain the created work item ID")
+                .isNotNull()
+                .isEqualTo(workItems.get(0).getId());
+    }
+
     /*
      * Helper methods
      */


### PR DESCRIPTION
…work_item_id on enter node events

  
Closes: https://github.com/apache/incubator-kie-issues/issues/2355

 


