### PR TITLE
[incubator-kie-issues#2361] fix CWE for Log Forging

### DIFF
--- a/drools/kogito-pmml/src/main/java/org/kie/kogito/pmml/AbstractPMMLRestResource.java
+++ b/drools/kogito-pmml/src/main/java/org/kie/kogito/pmml/AbstractPMMLRestResource.java
@@ -40,9 +40,10 @@ public abstract class AbstractPMMLRestResource {
     }
 
     public static String getJsonErrorMessage(Exception e) {
+        String rawMessage = e.getMessage() != null ? e.getMessage() : "";
+        String sanitizedMessage = rawMessage.replaceAll("[\r\n]", "_");
         String errorMessage = String.format("%s: %s",
-                e.getClass().getName(),
-                e.getMessage() != null ? e.getMessage() : "");
+                e.getClass().getName(), sanitizedMessage);
 
         Logger.getLogger(ErrorHandler.class.getName()).log(Level.SEVERE, errorMessage, e);
 

--- a/drools/kogito-pmml/src/main/java/org/kie/kogito/pmml/AbstractPMMLRestResource.java
+++ b/drools/kogito-pmml/src/main/java/org/kie/kogito/pmml/AbstractPMMLRestResource.java
@@ -41,7 +41,7 @@ public abstract class AbstractPMMLRestResource {
 
     public static String getJsonErrorMessage(Exception e) {
         String rawMessage = e.getMessage() != null ? e.getMessage() : "";
-        String sanitizedMessage = rawMessage.replaceAll("[\r\n]", "_");
+        String sanitizedMessage = rawMessage.replaceAll("\\R+", "_");
         String errorMessage = String.format("%s: %s",
                 e.getClass().getName(), sanitizedMessage);
 


### PR DESCRIPTION
Fixes : https://github.com/apache/incubator-kie-issues/issues/2361

Sanitized exception messages by replacing newline characters **(\r/\n)** with **(_)** to prevent log forging. This ensures user-controlled input cannot inject or forge additional log entries while preserving message readability.


