### PR TITLE
[incubator-kie-issues-2363] Migrate EscalationEventTest methods from v7 legacy runtime to code generation

### DIFF
--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventInterruptingModel;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventInterruptingProcess;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventModel;
+import org.jbpm.bpmn2.escalation.EscalationBoundaryEventOnTaskInterruptingModel;
+import org.jbpm.bpmn2.escalation.EscalationBoundaryEventOnTaskInterruptingProcess;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventProcess;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventWithTaskModel;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventWithTaskProcess;
@@ -54,7 +56,6 @@ import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.event.process.SignalEvent;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.kogito.Application;
-import org.kie.kogito.auth.SecurityPolicy;
 import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
 import org.kie.kogito.internal.process.event.KogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
@@ -245,12 +246,13 @@ public class EscalationEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInterruptingEscalationBoundaryEventOnTask() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/escalation/BPMN2-EscalationBoundaryEventOnTaskInterrupting.bpmn2");
-
+        Application app = ProcessTestHelper.newApplication();
+        ProcessTestHelper.registerProcessEventListener(app, LOGGING_EVENT_LISTENER);
         TestUserTaskWorkItemHandler workItemHandler = new TestUserTaskWorkItemHandler();
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        kruntime.getProcessEventManager().addEventListener(LOGGING_EVENT_LISTENER);
-        KogitoProcessInstance processInstance = kruntime.startProcess("EscalationBoundaryEventOnTaskInterrupting");
+        ProcessTestHelper.registerHandler(app, "Human Task", workItemHandler);
+        org.kie.kogito.process.Process<EscalationBoundaryEventOnTaskInterruptingModel> processDefinition = EscalationBoundaryEventOnTaskInterruptingProcess.newProcess(app);
+        org.kie.kogito.process.ProcessInstance<EscalationBoundaryEventOnTaskInterruptingModel> processInstance = processDefinition.createInstance(processDefinition.createModel());
+        processInstance.start();
 
         List<KogitoWorkItem> workItems = workItemHandler.getWorkItems();
         assertThat(workItems).hasSize(2);
@@ -260,8 +262,11 @@ public class EscalationEventTest extends JbpmBpmn2TestCase {
             workItem = workItems.get(1);
         }
 
-        kruntime.getKogitoWorkItemManager().completeWorkItem(workItem.getStringId(), Collections.emptyMap(), SecurityPolicy.of("john", Collections.emptyList()));
-        assertProcessInstanceFinished(processInstance, kruntime);
+        // completing john's task throws escalation which interrupts mary's UserTask via boundary event
+        ProcessTestHelper.completeWorkItem(processInstance, Collections.emptyMap(), "john");
+        // mary's task is interrupted by the boundary event, completing remaining work item
+        ProcessTestHelper.completeWorkItem(processInstance, Collections.emptyMap(), "mary");
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
 
     @Test

--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.jbpm.bpmn2.escalation.EscalationBoundaryEventInterruptingModel;
+import org.jbpm.bpmn2.escalation.EscalationBoundaryEventInterruptingProcess;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventModel;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventProcess;
 import org.jbpm.bpmn2.escalation.EscalationBoundaryEventWithTaskModel;
@@ -186,11 +188,16 @@ public class EscalationEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEscalationBoundaryEventInterrupting() throws Exception {
-        kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/escalation/BPMN2-EscalationBoundaryEventInterrupting.bpmn2");
+        Application app = ProcessTestHelper.newApplication();
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("MyTask", handler);
-        KogitoProcessInstance processInstance = kruntime.startProcess("EscalationBoundaryEventInterrupting");
-        assertProcessInstanceCompleted(processInstance);
+        ProcessTestHelper.registerHandler(app, "MyTask", handler);
+        org.kie.kogito.process.Process<EscalationBoundaryEventInterruptingModel> processDefinition = EscalationBoundaryEventInterruptingProcess.newProcess(app);
+        org.kie.kogito.process.ProcessInstance<EscalationBoundaryEventInterruptingModel> processInstance = processDefinition.createInstance(processDefinition.createModel());
+        processInstance.start();
+        KogitoWorkItem workItem = handler.getWorkItem();
+        assertThat(workItem).isNotNull();
+        ProcessTestHelper.completeWorkItem(processInstance, Collections.emptyMap(), "john");
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/2363

Migrated escalation event handling tests which are being compiled using 
legacy v7 to code generation approach.

The tests can be identified by referring to EscalationEventTest.java:
https://github.com/apache/incubator-kie-kogito-runtimes/blob/main/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/EscalationEventTest.java

## Tests Migrated

**testEscalationBoundaryEventInterrupting()**
- Migrates escalation boundary event on a subprocess
- Uses `EscalationBoundaryEventInterruptingProcess` and `EscalationBoundaryEventInterruptingModel`
- Boundary event is interrupting (`cancelActivity=true`) — cancels the subprocess
- Explicitly completes the `MyTask` work item via `ProcessTestHelper.completeWorkItem()`
- BPMN: `BPMN2-EscalationBoundaryEventInterrupting.bpmn2`

**testInterruptingEscalationBoundaryEventOnTask()**
- Migrates interrupting escalation boundary event on a parallel user task flow
- Uses `EscalationBoundaryEventOnTaskInterruptingProcess` and model
- Parallel gateway splits into john's task (throws escalation) and mary's task (interrupted by boundary)
- Completes john's task first (triggers escalation), then mary's task (interrupted path)
- Replaces `SecurityPolicy.of("john", ...)` with user name string directly in `ProcessTestHelper`
- BPMN: `BPMN2-EscalationBoundaryEventOnTaskInterrupting.bpmn2`

## Migration Changes
- Replaced `createKogitoProcessRuntime()` with generated process classes
- Used `ProcessTestHelper` for application, handler and event listener setup
- Replaced `kruntime.startProcess()` with `processDefinition.createInstance(model).start()`
- Replaced `kruntime.getKogitoWorkItemManager().completeWorkItem()` with `ProcessTestHelper.completeWorkItem()`
- Replaced `SecurityPolicy.of()` with user name string directly
- Replaced `assertProcessInstanceCompleted()` and `assertProcessInstanceFinished()` 
  with direct `processInstance.status()` check

## BPMN Files
- `BPMN2-EscalationBoundaryEventInterrupting.bpmn2` (test 1)
- `BPMN2-EscalationBoundaryEventOnTaskInterrupting.bpmn2` (test 2)