### PR TITLE
NO-ISSUE : fix CWE-470 validate rule unit class name before loadClass

### DIFF
--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/RuleUnitServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/RuleUnitServiceImpl.java
@@ -20,6 +20,7 @@ package org.kie.kogito.core.rules.incubation.quarkus.support;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.drools.ruleunits.api.RuleUnit;
@@ -35,6 +36,9 @@ import org.kie.kogito.incubation.rules.RuleUnitId;
 import org.kie.kogito.incubation.rules.services.RuleUnitService;
 
 class RuleUnitServiceImpl implements RuleUnitService {
+
+    // CWE-470: validate class name is a legal Java FQCN before passing to loadClass
+    private static final Pattern SAFE_CLASS_NAME = Pattern.compile("[\\w$]+(\\.[\\w$]+)*");
 
     private final RuleUnits ruleUnits;
 
@@ -64,12 +68,16 @@ class RuleUnitServiceImpl implements RuleUnitService {
     }
 
     private RuleUnitData convertValue(Map<String, Object> payload, RuleUnitId ruleUnitId) {
+        String className = ruleUnitId.ruleUnitId();
+        if (!SAFE_CLASS_NAME.matcher(className).matches()) {
+            throw new IllegalArgumentException("Invalid rule unit class name: " + className);
+        }
         try {
             // converts the identifier into a Class object for conversion
-            Class<RuleUnitData> type = (Class<RuleUnitData>) Thread.currentThread().getContextClassLoader().loadClass(ruleUnitId.ruleUnitId());
+            Class<RuleUnitData> type = (Class<RuleUnitData>) Thread.currentThread().getContextClassLoader().loadClass(className);
             return InternalObjectMapper.objectMapper().convertValue(payload, type);
         } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException("Cannot load class " + ruleUnitId.ruleUnitId(), e);
+            throw new IllegalArgumentException("Cannot load class " + className, e);
         }
     }
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java
@@ -21,6 +21,7 @@ package org.kie.kogito.core.rules.incubation.quarkus.support;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.drools.ruleunits.api.RuleUnit;
@@ -40,6 +41,9 @@ import org.kie.kogito.incubation.rules.RuleUnitInstanceId;
 import org.kie.kogito.incubation.rules.services.StatefulRuleUnitService;
 
 class StatefulRuleUnitServiceImpl implements StatefulRuleUnitService {
+
+    // CWE-470: validate class name is a legal Java FQCN before passing to loadClass
+    private static final Pattern SAFE_CLASS_NAME = Pattern.compile("[\\w$]+(\\.[\\w$]+)*");
 
     private final RuleUnits ruleUnits;
 
@@ -71,8 +75,12 @@ class StatefulRuleUnitServiceImpl implements StatefulRuleUnitService {
     }
 
     private Class<RuleUnitData> toClass(RuleUnitId ruleUnitId) {
+        String className = ruleUnitId.ruleUnitId();
+        if (!SAFE_CLASS_NAME.matcher(className).matches()) {
+            throw new IllegalArgumentException("Invalid rule unit class name: " + className);
+        }
         try {
-            return (Class<RuleUnitData>) Thread.currentThread().getContextClassLoader().loadClass(ruleUnitId.ruleUnitId());
+            return (Class<RuleUnitData>) Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException(e);
         }

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java
@@ -82,7 +82,7 @@ class StatefulRuleUnitServiceImpl implements StatefulRuleUnitService {
         try {
             return (Class<RuleUnitData>) Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException("Cannot load class " + className, e);
         }
     }
 


### PR DESCRIPTION
Fix: CWE-470 Unsafe Reflection — Validate Rule Unit Class Name Before loadClass
Added a compiled Pattern constant SAFE_CLASS_NAME in both affected classes to validate that the class name is a legal Java fully-qualified class name before it reaches loadClass().

*Validation pattern:* [\w$]+(\.[\w$]+)*

This pattern accepts only dot-separated Java identifier segments (letters, digits, underscore, dollar sign). Any other character — including path separators, semicolons, spaces, or special characters — causes an IllegalArgumentException to be thrown before loadClass() is called.

*Files changed:*
* quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/RuleUnitServiceImpl.java
* quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java