### PR TITLE
[incubator-kie-issues#2377] Message start event without data mapping fails code generation

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
@@ -69,7 +69,7 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
         }
 
         String type = null;
-        if (itemRef != null && itemRef.trim().length() > 0) {
+        if (itemRef != null && !itemRef.trim().isEmpty()) {
             Map<String, ItemDefinition> itemDefinitions = (Map<String, ItemDefinition>) ((ProcessBuildData) parser.getData()).getMetaData("ItemDefinitions");
             if (itemDefinitions == null) {
                 throw new ProcessParsingValidationException("No item definitions found");
@@ -80,8 +80,8 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
             }
             type = itemDefinition.getStructureRef();
         }
-        if (type == null || type.trim().length() == 0) {
-            type = "java.lang.Object";
+        if (type != null && type.trim().isEmpty()) {
+            type = null;
         }
 
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
@@ -68,13 +68,20 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
             name = id;
         }
 
-        Map<String, ItemDefinition> itemDefinitions = (Map<String, ItemDefinition>) ((ProcessBuildData) parser.getData()).getMetaData("ItemDefinitions");
-        if (itemDefinitions == null) {
-            throw new ProcessParsingValidationException("No item definitions found");
+        String type = null;
+        if (itemRef != null && itemRef.trim().length() > 0) {
+            Map<String, ItemDefinition> itemDefinitions = (Map<String, ItemDefinition>) ((ProcessBuildData) parser.getData()).getMetaData("ItemDefinitions");
+            if (itemDefinitions == null) {
+                throw new ProcessParsingValidationException("No item definitions found");
+            }
+            ItemDefinition itemDefinition = itemDefinitions.get(itemRef);
+            if (itemDefinition == null) {
+                throw new ProcessParsingValidationException("Could not find itemDefinition " + itemRef);
+            }
+            type = itemDefinition.getStructureRef();
         }
-        ItemDefinition itemDefinition = itemDefinitions.get(itemRef);
-        if (itemDefinition == null) {
-            throw new ProcessParsingValidationException("Could not find itemDefinition " + itemRef);
+        if (type == null || type.trim().length() == 0) {
+            type = "java.lang.Object";
         }
 
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();
@@ -84,12 +91,9 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
             buildData.setMetaData("Messages", messages);
         }
         Message message = new Message(id);
-        message.setType(itemDefinition.getStructureRef());
+        message.setType(type);
         message.setName(name);
-
-        if (message.getType() != null && !message.getType().isEmpty()) {
-            messages.put(id, message);
-        }
+        messages.put(id, message);
         return message;
     }
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -231,7 +231,11 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         // now we wire correlation process subscriptions
         CorrelationManager correlationManager = process.getCorrelationManager();
         for (Message message : HandlerUtil.messages(parser).values()) {
-            correlationManager.newMessage(message.getId(), message.getName(), message.getType());
+            String messageType = message.getType();
+            if (messageType == null || messageType.trim().isEmpty()) {
+                messageType = "java.lang.Object";
+            }
+            correlationManager.newMessage(message.getId(), message.getName(), messageType);
         }
 
         // only the ones this process is member of

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ServiceTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ServiceTaskHandler.java
@@ -76,7 +76,8 @@ public class ServiceTaskHandler extends TaskHandler {
             if (workItemNode.getWork().getParameter("Operation") == null) {
                 workItemNode.getWork().setParameter("Operation", operation.getName());
             }
-            if (workItemNode.getWork().getParameter("ParameterType") == null && operation.getMessage() != null) {
+            if (workItemNode.getWork().getParameter("ParameterType") == null && operation.getMessage() != null
+                    && operation.getMessage().getType() != null && !operation.getMessage().getType().trim().isEmpty()) {
                 workItemNode.getWork().setParameter("ParameterType", operation.getMessage().getType());
             }
             // parameters to support web service invocation 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractNodeVisitor.java
@@ -475,9 +475,10 @@ public abstract class AbstractNodeVisitor<T extends Node> extends AbstractVisito
 
     public static ObjectCreationExpr buildProducerAction(ClassOrInterfaceType actionClass, TriggerMetaData trigger, ProcessMetaData metadata) {
         metadata.addTrigger(trigger);
+        Expression modelRef = trigger.getModelRef() != null ? new StringLiteralExpr(trigger.getModelRef()) : new NullLiteralExpr();
         return new ObjectCreationExpr(null, actionClass, NodeList.nodeList(
                 new StringLiteralExpr(trigger.getName()),
-                new StringLiteralExpr(trigger.getModelRef()),
+                modelRef,
                 new LambdaExpr(NodeList.nodeList(),
                         new NameExpr("producer_" + trigger.getOwnerId()))));
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/TriggerMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/TriggerMetaData.java
@@ -70,12 +70,17 @@ public class TriggerMetaData {
     public static TriggerMetaData of(Node node, String mappingVariable) {
         Map<String, Object> nodeMetaData = node.getMetaData();
         String channelName = (String) nodeMetaData.getOrDefault(CHANNEL_NAME, (String) nodeMetaData.get(TRIGGER_REF));
+        TriggerType triggerType = TriggerType.valueOf((String) nodeMetaData.get(TRIGGER_TYPE));
+        String dataType = (String) nodeMetaData.get(MESSAGE_TYPE);
+        if ((TriggerType.ConsumeMessage.equals(triggerType) || TriggerType.ProduceMessage.equals(triggerType)) && StringUtils.isEmpty(dataType)) {
+            dataType = "java.lang.Object";
+        }
         return new TriggerMetaData(
                 node,
                 (String) nodeMetaData.get(TRIGGER_REF),
                 channelName,
-                TriggerType.valueOf((String) nodeMetaData.get(TRIGGER_TYPE)),
-                (String) nodeMetaData.get(MESSAGE_TYPE),
+                triggerType,
+                dataType,
                 mappingVariable,
                 getOwnerId(node),
                 (Boolean) nodeMetaData.get(DATA_ONLY),

--- a/jbpm/jbpm-tests/src/test/bpmn/org/jbpm/bpmn2/start/BPMN2-MessageStartNoMapping.bpmn2
+++ b/jbpm/jbpm-tests/src/test/bpmn/org/jbpm/bpmn2/start/BPMN2-MessageStartNoMapping.bpmn2
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<definitions id="Definition"
+             targetNamespace="http://www.example.org/MinimalExample"
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="HelloMessageType" structureRef="" />
+  <message id="HelloMessage" itemRef="HelloMessageType" />
+
+  <process processType="Private" isExecutable="true" id="MessageStartNoMapping" name="Message Start No Mapping" tns:packageName="org.jbpm.bpmn2.start" >
+
+    <!-- nodes -->
+    <startEvent id="_1" name="StartProcess" >
+      <messageEventDefinition messageRef="HelloMessage"/>
+    </startEvent>
+    <scriptTask id="_2" name="Hello" >
+      <script>System.out.println("Message received without data mapping");</script>
+    </scriptTask>
+    <endEvent id="_3" name="EndProcess" >
+        <terminateEventDefinition/>
+    </endEvent>
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="MessageStartNoMapping" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="16" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_2" >
+        <dc:Bounds x="96" y="16" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" >
+        <dc:Bounds x="208" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_1-_2" >
+        <di:waypoint x="40" y="40" />
+        <di:waypoint x="136" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_2-_3" >
+        <di:waypoint x="136" y="40" />
+        <di:waypoint x="232" y="40" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</definitions>

--- a/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StartEventTest.java
+++ b/jbpm/jbpm-tests/src/test/java/org/jbpm/bpmn2/StartEventTest.java
@@ -309,6 +309,22 @@ public class StartEventTest extends JbpmBpmn2TestCase {
     }
 
     @Test
+    public void testMessageStartWithoutDataMapping() throws Exception {
+        Application app = ProcessTestHelper.newApplication();
+        final List<ProcessInstance> startedProcesses = new ArrayList<>();
+        ProcessTestHelper.registerProcessEventListener(app, new DefaultKogitoProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                startedProcesses.add(event.getProcessInstance());
+            }
+        });
+        org.kie.kogito.process.Process<MessageStartNoMappingModel> definition = MessageStartNoMappingProcess.newProcess(app);
+        definition.send(SignalFactory.of("HelloMessage"));
+        assertThat(startedProcesses).hasSize(1);
+        assertThat(startedProcesses).extracting(ProcessInstance::getProcessId).containsExactly("MessageStartNoMapping");
+    }
+
+    @Test
     public void testMultipleStartEventsRegularStart() throws Exception {
         kruntime = createKogitoProcessRuntime("org/jbpm/bpmn2/start/BPMN2-MultipleStartEventProcessLongInterval.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/tests/MessageStartEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/tests/MessageStartEventIT.java
@@ -56,6 +56,24 @@ public class MessageStartEventIT extends AbstractCodegenIT {
     }
 
     @Test
+    public void testMessageStartEventWithoutDataMappingProcess() throws Exception {
+
+        Application app = generateCodeProcessesOnly("messagestartevent/MessageStartEventNoMapping.bpmn2");
+        assertThat(app).isNotNull();
+
+        Process<? extends Model> p = app.get(Processes.class).processById("MessageStartEventNoMapping");
+
+        Model m = p.createModel();
+
+        ProcessInstance<?> processInstance = p.createInstance(m);
+        processInstance.start("customers", null);
+
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+        Model result = (Model) processInstance.variables();
+        assertThat(result.toMap()).isEmpty();
+    }
+
+    @Test
     public void testMessageStartAndEndEventProcess() throws Exception {
 
         Application app = generateCodeProcessesOnly("messagestartevent/MessageStartAndEndEvent.bpmn2");

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/messagestartevent/MessageStartEventNoMapping.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/messagestartevent/MessageStartEventNoMapping.bpmn2
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:java="http://www.java.com/javaTypes" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:message id="Message_1" name="customers"/>
+  <bpmn2:process id="MessageStartEventNoMapping" tns:packageName="org.kie.kogito.test" name="MessageStartEventNoMapping" isExecutable="true" processType="Public">
+    <bpmn2:startEvent id="StartEvent_1" name="StartProcess">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[StartProcess]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1"/>
+    </bpmn2:startEvent>
+    <bpmn2:scriptTask id="ScriptTask_1" name="Script Task 1" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Script Task 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;Message received&quot;);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" sourceRef="StartEvent_1" targetRef="ScriptTask_1"/>
+    <bpmn2:endEvent id="EndEvent_1" name="End Event 1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[End Event 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" tns:priority="1" sourceRef="ScriptTask_1" targetRef="EndEvent_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="MessageStartEventNoMapping">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="120.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ScriptTask_1" bpmnElement="ScriptTask_1" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="261.0" y="93.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="439.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_ScriptTask_1">
+        <di:waypoint xsi:type="dc:Point" x="156.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="261.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_ScriptTask_1" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="371.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="439.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/MessageConsumerGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/MessageConsumerGenerator.java
@@ -40,6 +40,7 @@ import org.kie.kogito.event.cloudevents.utils.CloudEventUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier.Keyword;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
@@ -52,6 +53,7 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
@@ -152,13 +154,16 @@ public class MessageConsumerGenerator {
     }
 
     private void generateModelMethods(ClassOrInterfaceDeclaration template) {
-        //generate setter call on eventToModel method
-        template.findAll(MethodCallExpr.class)
-                .forEach(t -> {
-                    String name = (String) trigger.getNode().getMetaData().get(Metadata.MAPPING_VARIABLE);
-                    name = Optional.ofNullable(name).orElseGet(() -> trigger.getModelRef());
-                    t.setName(t.getNameAsString().replace("$SetModelMethodName$", "set" + StringUtils.ucFirst(name)));
-                });
+        String mappedVariable = (String) trigger.getNode().getMetaData().get(Metadata.MAPPING_VARIABLE);
+        mappedVariable = Optional.ofNullable(mappedVariable).orElseGet(() -> trigger.getModelRef());
+        if (mappedVariable == null) {
+            template.findAll(MethodDeclaration.class, m -> m.getName().getIdentifier().equals("eventToModel"))
+                    .forEach(m -> m.getBody().ifPresent(body -> body.findAll(IfStmt.class).forEach(Node::remove)));
+        } else {
+            String setModelMethodName = "set" + StringUtils.ucFirst(mappedVariable);
+            template.findAll(MethodCallExpr.class)
+                    .forEach(t -> t.setName(t.getNameAsString().replace("$SetModelMethodName$", setModelMethodName)));
+        }
 
         if (!(trigger.getNode() instanceof StartNode)) {
             template.findAll(MethodDeclaration.class, m -> m.getName().getIdentifier().equals("getModelConverter")).stream().findFirst().ifPresent(template::remove);
@@ -201,8 +206,8 @@ public class MessageConsumerGenerator {
 
     private void interpolateStrings(MethodCallExpr vv) {
         String s = vv.getNameAsString();
-        String interpolated =
-                s.replace("$DataType$", StringUtils.ucFirst(trigger.getModelRef()));
-        vv.setName(interpolated);
+        if (s.contains("$DataType$")) {
+            vv.setName(s.replace("$DataType$", StringUtils.ucFirst(trigger.getModelRef())));
+        }
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/events/CodegenMessageStartEventTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/events/CodegenMessageStartEventTest.java
@@ -38,6 +38,8 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
@@ -57,6 +59,8 @@ public class CodegenMessageStartEventTest {
     private static final Path MESSAGE_START_EVENT_NO_MAPPING_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_START_EVENT_NO_MAPPING_SOURCE);
     private static final String MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_SOURCE = "messagestartevent/MessageStartEventEmptyStructureRef.bpmn2";
     private static final Path MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_SOURCE);
+    private static final String MESSAGE_END_EVENT_NO_MAPPING_SOURCE = "messagestartevent/MessageEndEventNoMapping.bpmn2";
+    private static final Path MESSAGE_END_EVENT_NO_MAPPING_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_END_EVENT_NO_MAPPING_SOURCE);
 
     @ParameterizedTest
     @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#restContextBuilders")
@@ -148,6 +152,68 @@ public class CodegenMessageStartEventTest {
         assertThat(correlationMessages.get(0).getArgument(2).asStringLiteralExpr().getValue())
                 .withFailMessage("An empty structureRef carries no data, so the message type must default to java.lang.Object")
                 .isEqualTo("java.lang.Object");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#restContextBuilders")
+    public void testMessageEndEventWithoutDataMapping(KogitoBuildContext.Builder contextBuilder) {
+        contextBuilder
+                .withClassAvailabilityResolver(mockClassAvailabilityResolver(singleton(KogitoCodeGenConstants.QUARKUS_TRANSACTION_MANAGER_CLASS), emptyList()));
+        KogitoBuildContext context = contextBuilder.build();
+        ProcessCodegen codeGenerator = ProcessCodegen.ofCollectedResources(
+                context,
+                CollectedResourceProducer.fromFiles(BASE_PATH, MESSAGE_END_EVENT_NO_MAPPING_FULL_SOURCE.toFile()));
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        assertThat(generatedFiles).isNotEmpty();
+
+        List<GeneratedFile> processes = generatedFiles.stream()
+                .filter(generatedFile -> generatedFile.relativePath().endsWith("org/kie/kogito/test/MessageEndEventNoMappingProcess.java"))
+                .collect(Collectors.toList());
+        assertThat(processes).hasSize(1);
+
+        CompilationUnit parsedProcess = StaticJavaParser.parse(new String(processes.get(0).contents()));
+
+        List<ObjectCreationExpr> producerActions = parsedProcess.findAll(ObjectCreationExpr.class,
+                objectCreation -> objectCreation.getType().getNameAsString().equals("ProduceEventAction"));
+        assertThat(producerActions).hasSize(1);
+        assertThat(producerActions.get(0).getArgument(1))
+                .withFailMessage("A message end event without data mapping has no variable to send, so no variable name must be passed")
+                .isInstanceOf(NullLiteralExpr.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    public void testMessageConsumerForMessageStartEventWithoutDataMapping(KogitoBuildContext.Builder contextBuilder) {
+        Properties properties = new Properties();
+        properties.put("kogito.addon.cloudevents.kafka.kogito_outgoing_stream", "test-out");
+        properties.put("kogito.addon.cloudevents.kafka.kogito_incoming_stream", "test-in");
+        contextBuilder.withApplicationProperties(properties);
+
+        KogitoBuildContext context = contextBuilder.build();
+        ProcessCodegen codeGenerator = ProcessCodegen.ofCollectedResources(
+                context,
+                CollectedResourceProducer.fromFiles(BASE_PATH, MESSAGE_START_EVENT_NO_MAPPING_FULL_SOURCE.toFile()));
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        assertThat(generatedFiles).isNotEmpty();
+
+        List<GeneratedFile> consumers = generatedFiles.stream()
+                .filter(generatedFile -> generatedFile.relativePath().endsWith("org/kie/kogito/test/MessageStartEventNoMappingMessageConsumer_StartEvent_1.java"))
+                .collect(Collectors.toList());
+        assertThat(consumers).hasSize(1);
+
+        CompilationUnit parsedConsumer = StaticJavaParser.parse(new String(consumers.get(0).contents()));
+
+        assertThat(parsedConsumer.findAll(MethodCallExpr.class, mc -> mc.getNameAsString().contains("$SetModelMethodName$")))
+                .withFailMessage("A message without data mapping has no variable to set on the model")
+                .isEmpty();
+
+        if (context.hasDI()) {
+            assertThat(parsedConsumer.findFirst(MethodDeclaration.class, md -> "getModelConverter".equals(md.getNameAsString())))
+                    .withFailMessage("The model converter must be kept, otherwise the message would not start the process")
+                    .isPresent();
+        }
     }
 
     @ParameterizedTest

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/events/CodegenMessageStartEventTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/events/CodegenMessageStartEventTest.java
@@ -37,6 +37,7 @@ import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
@@ -52,6 +53,10 @@ public class CodegenMessageStartEventTest {
     private static final Path MESSAGE_END_EVENT_SOURCE_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_END_EVENT_SOURCE);
     private static final String MESSAGE_START_END_EVENT_SOURCE = "messagestartevent/MessageStartAndEndEvent.bpmn2";
     private static final Path MESSAGE_START_END_EVENT_SOURCE_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_START_END_EVENT_SOURCE);
+    private static final String MESSAGE_START_EVENT_NO_MAPPING_SOURCE = "messagestartevent/MessageStartEventNoMapping.bpmn2";
+    private static final Path MESSAGE_START_EVENT_NO_MAPPING_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_START_EVENT_NO_MAPPING_SOURCE);
+    private static final String MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_SOURCE = "messagestartevent/MessageStartEventEmptyStructureRef.bpmn2";
+    private static final Path MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_SOURCE);
 
     @ParameterizedTest
     @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#restContextBuilders")
@@ -83,6 +88,66 @@ public class CodegenMessageStartEventTest {
             assertThat(resources).isEmpty();
         }
 
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#restContextBuilders")
+    public void testMessageStartEventWithoutItemRef(KogitoBuildContext.Builder contextBuilder) {
+        contextBuilder
+                .withClassAvailabilityResolver(mockClassAvailabilityResolver(singleton(KogitoCodeGenConstants.QUARKUS_TRANSACTION_MANAGER_CLASS), emptyList()));
+        KogitoBuildContext context = contextBuilder.build();
+        ProcessCodegen codeGenerator = ProcessCodegen.ofCollectedResources(
+                context,
+                CollectedResourceProducer.fromFiles(BASE_PATH, MESSAGE_START_EVENT_NO_MAPPING_FULL_SOURCE.toFile()));
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        assertThat(generatedFiles).isNotEmpty();
+
+        List<GeneratedFile> processes = generatedFiles.stream()
+                .filter(generatedFile -> generatedFile.relativePath().endsWith("org/kie/kogito/test/MessageStartEventNoMappingProcess.java"))
+                .collect(Collectors.toList());
+        assertThat(processes).hasSize(1);
+
+        CompilationUnit parsedProcess = StaticJavaParser.parse(new String(processes.get(0).contents()));
+
+        List<MethodCallExpr> correlationMessages = parsedProcess.findAll(MethodCallExpr.class,
+                methodCall -> "newCorrelationMessage".equals(methodCall.getNameAsString()));
+        assertThat(correlationMessages)
+                .withFailMessage("A message without itemRef must still be registered as a correlation message")
+                .hasSize(1);
+        assertThat(correlationMessages.get(0).getArgument(2).asStringLiteralExpr().getValue())
+                .withFailMessage("A message without itemRef carries no data, so its type must default to java.lang.Object")
+                .isEqualTo("java.lang.Object");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#restContextBuilders")
+    public void testMessageStartEventWithEmptyStructureRef(KogitoBuildContext.Builder contextBuilder) {
+        contextBuilder
+                .withClassAvailabilityResolver(mockClassAvailabilityResolver(singleton(KogitoCodeGenConstants.QUARKUS_TRANSACTION_MANAGER_CLASS), emptyList()));
+        KogitoBuildContext context = contextBuilder.build();
+        ProcessCodegen codeGenerator = ProcessCodegen.ofCollectedResources(
+                context,
+                CollectedResourceProducer.fromFiles(BASE_PATH, MESSAGE_START_EVENT_EMPTY_STRUCTURE_REF_FULL_SOURCE.toFile()));
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        assertThat(generatedFiles).isNotEmpty();
+
+        List<GeneratedFile> processes = generatedFiles.stream()
+                .filter(generatedFile -> generatedFile.relativePath().endsWith("org/kie/kogito/test/MessageStartEventEmptyStructureRefProcess.java"))
+                .collect(Collectors.toList());
+        assertThat(processes).hasSize(1);
+
+        CompilationUnit parsedProcess = StaticJavaParser.parse(new String(processes.get(0).contents()));
+
+        List<MethodCallExpr> correlationMessages = parsedProcess.findAll(MethodCallExpr.class,
+                methodCall -> "newCorrelationMessage".equals(methodCall.getNameAsString()));
+        assertThat(correlationMessages)
+                .withFailMessage("A message pointing to an itemDefinition with an empty structureRef must still be registered as a correlation message")
+                .hasSize(1);
+        assertThat(correlationMessages.get(0).getArgument(2).asStringLiteralExpr().getValue())
+                .withFailMessage("An empty structureRef carries no data, so the message type must default to java.lang.Object")
+                .isEqualTo("java.lang.Object");
     }
 
     @ParameterizedTest

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/resources/messagestartevent/MessageEndEventNoMapping.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/resources/messagestartevent/MessageEndEventNoMapping.bpmn2
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:tns="http://www.jboss.org/drools" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:message id="Message_1" name="processedcustomers"/>
+  <bpmn2:process id="MessageEndEventNoMapping" tns:packageName="org.kie.kogito.test" name="MessageEndEventNoMapping" isExecutable="true" processType="Public">
+    <bpmn2:startEvent id="StartEvent_1" name="StartProcess">
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" tns:priority="1" sourceRef="StartEvent_1" targetRef="EndEvent_1"/>
+    <bpmn2:endEvent id="EndEvent_1" name="SendMessage">
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="MessageEndEventNoMapping">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="120.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="300.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="156.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="300.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/resources/messagestartevent/MessageStartEventEmptyStructureRef.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/resources/messagestartevent/MessageStartEventEmptyStructureRef.bpmn2
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_1LzeAD1AED-4ytPGpMdr_Q" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="HelloMessageType" structureRef=""/>
+  <bpmn2:itemDefinition id="_0CCC1AF7-773D-47B9-B84F-2E766A1A422B" structureRef=""/>
+  <bpmn2:itemDefinition id="_82170791-2215-4C50-82FF-E10D4F4A6765" structureRef=""/>
+  <bpmn2:message id="_1L0FED1AED-4ytPGpMdr_Q" itemRef="HelloMessageType" name="HelloMessage"/>
+  <bpmn2:collaboration id="_14C40EAD-55BF-480D-A048-E916353DE4D4" name="Default Collaboration">
+    <bpmn2:participant id="_66D20077-8CC7-4712-9011-6F9076BE243D" name="Pool Participant" processRef="MessageStartEventEmptyStructureRef"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="MessageStartEventEmptyStructureRef" drools:packageName="org.kie.kogito.test" drools:version="1.0" drools:adHoc="false" name="MessageStartEventEmptyStructureRef" isExecutable="true" processType="Public">
+    <bpmn2:sequenceFlow id="_EE47D218-4FAF-4EE6-8007-80097CEEB65D" sourceRef="_C7D5472F-DE97-46E7-9003-778E2CD89C29" targetRef="_04380D05-0FD1-4F44-AFD8-3B3CB39EEBFD"/>
+    <bpmn2:sequenceFlow id="_026AC3E5-EA00-426C-ACD6-8BCAAC8B09D5" sourceRef="_B5F5824A-61E9-4E75-9289-4A14CE2C0E23" targetRef="_C7D5472F-DE97-46E7-9003-778E2CD89C29">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_04380D05-0FD1-4F44-AFD8-3B3CB39EEBFD">
+      <bpmn2:incoming>_EE47D218-4FAF-4EE6-8007-80097CEEB65D</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:scriptTask id="_C7D5472F-DE97-46E7-9003-778E2CD89C29" name="Script task" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Script task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_026AC3E5-EA00-426C-ACD6-8BCAAC8B09D5</bpmn2:incoming>
+      <bpmn2:outgoing>_EE47D218-4FAF-4EE6-8007-80097CEEB65D</bpmn2:outgoing>
+      <bpmn2:script>System.out.println("Received event NO data mapping");</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:startEvent id="_B5F5824A-61E9-4E75-9289-4A14CE2C0E23">
+      <bpmn2:outgoing>_026AC3E5-EA00-426C-ACD6-8BCAAC8B09D5</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition drools:msgref="HelloMessage" messageRef="_1L0FED1AED-4ytPGpMdr_Q"/>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="MessageStartEventEmptyStructureRef">
+      <bpmndi:BPMNShape id="shape__B5F5824A-61E9-4E75-9289-4A14CE2C0E23" bpmnElement="_B5F5824A-61E9-4E75-9289-4A14CE2C0E23">
+        <dc:Bounds height="56" width="56" x="411" y="221"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__C7D5472F-DE97-46E7-9003-778E2CD89C29" bpmnElement="_C7D5472F-DE97-46E7-9003-778E2CD89C29">
+        <dc:Bounds height="102" width="154" x="571" y="198"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__04380D05-0FD1-4F44-AFD8-3B3CB39EEBFD" bpmnElement="_04380D05-0FD1-4F44-AFD8-3B3CB39EEBFD">
+        <dc:Bounds height="56" width="56" x="829" y="221"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__B5F5824A-61E9-4E75-9289-4A14CE2C0E23_to_shape__C7D5472F-DE97-46E7-9003-778E2CD89C29" bpmnElement="_026AC3E5-EA00-426C-ACD6-8BCAAC8B09D5">
+        <di:waypoint x="439" y="249"/>
+        <di:waypoint x="571" y="249"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__C7D5472F-DE97-46E7-9003-778E2CD89C29_to_shape__04380D05-0FD1-4F44-AFD8-3B3CB39EEBFD" bpmnElement="_EE47D218-4FAF-4EE6-8007-80097CEEB65D">
+        <di:waypoint x="648" y="249"/>
+        <di:waypoint x="829" y="249"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_C7D5472F-DE97-46E7-9003-778E2CD89C29">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_1LzeAD1AED-4ytPGpMdr_Q</bpmn2:source>
+    <bpmn2:target>_1LzeAD1AED-4ytPGpMdr_Q</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/resources/messagestartevent/MessageStartEventNoMapping.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/resources/messagestartevent/MessageStartEventNoMapping.bpmn2
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:java="http://www.java.com/javaTypes" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:message id="Message_1" name="customers"/>
+  <bpmn2:process id="MessageStartEventNoMapping" tns:packageName="org.kie.kogito.test" name="MessageStartEventNoMapping" isExecutable="true" processType="Public">
+    <bpmn2:startEvent id="StartEvent_1" name="StartProcess">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[StartProcess]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1"/>
+    </bpmn2:startEvent>
+    <bpmn2:scriptTask id="ScriptTask_1" name="Script Task 1" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Script Task 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;Message received&quot;);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" sourceRef="StartEvent_1" targetRef="ScriptTask_1"/>
+    <bpmn2:endEvent id="EndEvent_1" name="End Event 1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[End Event 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" tns:priority="1" sourceRef="ScriptTask_1" targetRef="EndEvent_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="MessageStartEventNoMapping">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="120.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ScriptTask_1" bpmnElement="ScriptTask_1" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="261.0" y="93.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="439.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_ScriptTask_1">
+        <di:waypoint xsi:type="dc:Point" x="156.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="261.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_ScriptTask_1" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="371.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="439.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
- **MessageHandler**:  message with no `itemRef` has no data, so only look up the itemDefinition when an `itemRef` is actually there (looking it up when it's missing is what caused the error). Still register the message so the event can find it, just with no type.

- **ServiceTaskHandler**:  a Java service task uses a message to describe the method it calls (like the argument type). Now that a no-data message has no type, reading the type from it would leave the service task with nothing and break code generation. So when the message has no type, skip it and get the argument type from the service task's own data inputs instead.

- **ProcessHandler** and **TriggerMetaData**: for a message event, code generation needs a real type. A no-data message doesn't have one, so it defaults to `java.lang.Object` in these two spots.

**Tests**
- `CodegenMessageStartEventTest`:  a message with no `itemRef`, and an itemDefinition with an empty `structureRef`.
- `StartEventTest.testMessageStartWithoutDataMapping`:  sends the message with no payload and checks the process starts.


closes: https://github.com/apache/incubator-kie-issues/issues/2377